### PR TITLE
doc: add link to plan9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # r9
-Plan 9 in Rust
+[Plan 9](https://plan9.io/plan9/) in Rust
 
 R9 is a reimplementation of the plan9 kernel in Rust.  It is
 not only inspired by but in many ways derived from the original
-Plan 9 source code.
+[Plan 9](https://plan9.io/plan9/) source code.
 
 ## Building
 


### PR DESCRIPTION
Just adds a link to the Plan 9 project.
I had to look for it because I didn't know what Plan 9 was. I guess other people will enjoy just having to click 😉 