### PR TITLE
main

### DIFF
--- a/riscv64/src/platform/mod.rs
+++ b/riscv64/src/platform/mod.rs
@@ -3,7 +3,7 @@ pub mod nezha;
 #[cfg(platform = "nezha")]
 pub use crate::platform::nezha::*;
 
-#[cfg(not(platform = "nezha"))]
+#[cfg(platform = "virt")]
 pub mod virt;
-#[cfg(not(platform = "nezha"))]
+#[cfg(platform = "virt")]
 pub use crate::platform::virt::*;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -481,8 +481,12 @@ fn run(build_params: &BuildParams) -> Result<()> {
                 cmd.arg("-machine").arg("virt");
             }
             cmd.arg("-cpu").arg("rv64");
-            cmd.arg("-drive").arg("file=disk.bin,format=raw,id=hd0");
-            cmd.arg("-device").arg("virtio-blk-device,drive=hd0");
+            // FIXME: This is not needed as of now, and will only work once the
+            // FIXME: // disk.bin is also taken care of. Doesn't exist by default.
+            if false {
+                cmd.arg("-drive").arg("file=disk.bin,format=raw,id=hd0");
+                cmd.arg("-device").arg("virtio-blk-device,drive=hd0");
+            }
             cmd.arg("-netdev").arg("type=user,id=net0");
             cmd.arg("-device").arg("virtio-net-device,netdev=net0");
             cmd.arg("-smp").arg("4");


### PR DESCRIPTION
- xtask: omit disk image on RISC-V for now
- riscv64/platform: use positive matching on the respective platform
