### PR TITLE
Fix/disable all warnings for aarch64

### DIFF
--- a/aarch64/src/devcons.rs
+++ b/aarch64/src/devcons.rs
@@ -31,7 +31,7 @@ use port::fdt::DeviceTree;
 //     https://wiki.osdev.org/Detecting_Raspberry_Pi_Board
 // - Break out mailbox, gpio code
 
-pub fn init(dt: &DeviceTree) {
+pub fn init(_dt: &DeviceTree) {
     Console::new(|| {
         const KZERO: u64 = 0xffff800000000000;
         let base = KZERO + MidrEl1::read().partnum_enum().map(|p| p.mmio()).unwrap_or(0);

--- a/aarch64/src/io.rs
+++ b/aarch64/src/io.rs
@@ -9,6 +9,7 @@ pub enum GpioPull {
 }
 
 /// Delay for count cycles
+#[allow(dead_code)]
 pub fn delay(count: u32) {
     for _ in 0..count {
         core::hint::spin_loop();
@@ -26,6 +27,7 @@ pub fn write_reg(reg: RegBlock, offset: u64, val: u32) {
 /// Write val|old into the reg RegBlock at offset from reg.addr,
 /// where `old` is the existing value.
 /// Panics if offset is outside any range specified by reg.len.
+#[allow(dead_code)]
 pub fn write_or_reg(reg: RegBlock, offset: u64, val: u32) {
     let dst = reg.addr + offset;
     assert!(reg.len.map_or(true, |len| offset < len));

--- a/aarch64/src/mailbox.rs
+++ b/aarch64/src/mailbox.rs
@@ -17,7 +17,7 @@ static MAILBOX: Lock<Option<&'static mut Mailbox>> = Lock::new("mailbox", None);
 /// Mailbox init.  Mainly initialises a lock to ensure only one mailbox request
 /// can be made at a time.  We have no heap at this point, so creating a mailbox
 /// that can be initialised based off the devicetree is rather convoluted.
-pub fn init(dt: &DeviceTree) {
+pub fn init(_dt: &DeviceTree) {
     static mut NODE: LockNode = LockNode::new();
     let mut mailbox = MAILBOX.lock(unsafe { &NODE });
     *mailbox = Some({
@@ -40,6 +40,7 @@ struct Mailbox {
     reg: RegBlock,
 }
 
+#[allow(dead_code)]
 impl Mailbox {
     fn new(dt: &DeviceTree, mmio_virt_offset: u64) -> Mailbox {
         Mailbox {
@@ -167,6 +168,7 @@ struct SetClockRateResponse {
     rate_hz: u32,
 }
 
+#[allow(dead_code)]
 pub fn set_clock_rate(clock_id: u32, rate_hz: u32, skip_setting_turbo: u32) {
     let tags = Tag::<SetClockRateRequest> {
         tag_id0: TagId::SetClockRate,

--- a/aarch64/src/registers.rs
+++ b/aarch64/src/registers.rs
@@ -3,31 +3,49 @@ use core::fmt;
 use num_enum::TryFromPrimitive;
 
 // GPIO registers
+#[allow(dead_code)]
 pub const GPFSEL1: u64 = 0x04; // GPIO function select register 1
+#[allow(dead_code)]
 pub const GPPUD: u64 = 0x94; // GPIO pin pull up/down enable
+#[allow(dead_code)]
 pub const GPPUDCLK0: u64 = 0x98; // GPIO pin pull up/down enable clock 0
 
 // UART 0 (PL011) registers
+#[allow(dead_code)]
 pub const UART0_DR: u64 = 0x00; // Data register
+#[allow(dead_code)]
 pub const UART0_FR: u64 = 0x18; // Flag register
+#[allow(dead_code)]
 pub const UART0_IBRD: u64 = 0x24; // Integer baud rate divisor
+#[allow(dead_code)]
 pub const UART0_FBRD: u64 = 0x28; // Fractional baud rate divisor
+#[allow(dead_code)]
 pub const UART0_LCRH: u64 = 0x2c; // Line control register
+#[allow(dead_code)]
 pub const UART0_CR: u64 = 0x30; // Control register
+#[allow(dead_code)]
 pub const UART0_IMSC: u64 = 0x38; // Interrupt mask set clear register
+#[allow(dead_code)]
 pub const UART0_ICR: u64 = 0x44; // Interrupt clear register
 
 // AUX registers, offset from aux_reg
+#[allow(dead_code)]
 pub const AUX_ENABLE: u64 = 0x04; // AUX enable register (Mini Uart, SPIs)
 
 // UART1 registers, offset from miniuart_reg
 pub const AUX_MU_IO: u64 = 0x00; // AUX IO data register
+#[allow(dead_code)]
 pub const AUX_MU_IER: u64 = 0x04; // Mini Uart interrupt enable register
+#[allow(dead_code)]
 pub const AUX_MU_IIR: u64 = 0x08; // Mini Uart interrupt identify register
+#[allow(dead_code)]
 pub const AUX_MU_LCR: u64 = 0x0c; // Mini Uart line control register
+#[allow(dead_code)]
 pub const AUX_MU_MCR: u64 = 0x10; // Mini Uart line control register
 pub const AUX_MU_LSR: u64 = 0x14; // Mini Uart line status register
+#[allow(dead_code)]
 pub const AUX_MU_CNTL: u64 = 0x20; // Mini Uart control register
+#[allow(dead_code)]
 pub const AUX_MU_BAUD: u64 = 0x28; // Mini Uart baudrate register
 
 bitstruct! {
@@ -43,12 +61,16 @@ bitstruct! {
 
 impl MidrEl1 {
     pub fn read() -> Self {
-        let mut value: u64 = 0;
         #[cfg(not(test))]
-        unsafe {
-            core::arch::asm!("mrs {value}, midr_el1", value = out(reg) value);
+        {
+            let mut value: u64;
+            unsafe {
+                core::arch::asm!("mrs {value}, midr_el1", value = out(reg) value);
+            }
+            Self(value)
         }
-        Self(value)
+        #[cfg(test)]
+        Self(0)
     }
 
     pub fn partnum_enum(&self) -> Result<PartNum, u16> {
@@ -168,6 +190,7 @@ bitstruct! {
     }
 }
 
+#[allow(dead_code)]
 impl EsrEl1IssInstructionAbort {
     pub fn from_esr_el1(r: EsrEl1) -> Option<EsrEl1IssInstructionAbort> {
         r.exception_class_enum()

--- a/aarch64/src/registers.rs
+++ b/aarch64/src/registers.rs
@@ -1,51 +1,35 @@
+#![allow(dead_code)]
+
 use bitstruct::bitstruct;
 use core::fmt;
 use num_enum::TryFromPrimitive;
 
 // GPIO registers
-#[allow(dead_code)]
 pub const GPFSEL1: u64 = 0x04; // GPIO function select register 1
-#[allow(dead_code)]
 pub const GPPUD: u64 = 0x94; // GPIO pin pull up/down enable
-#[allow(dead_code)]
 pub const GPPUDCLK0: u64 = 0x98; // GPIO pin pull up/down enable clock 0
 
 // UART 0 (PL011) registers
-#[allow(dead_code)]
 pub const UART0_DR: u64 = 0x00; // Data register
-#[allow(dead_code)]
 pub const UART0_FR: u64 = 0x18; // Flag register
-#[allow(dead_code)]
 pub const UART0_IBRD: u64 = 0x24; // Integer baud rate divisor
-#[allow(dead_code)]
 pub const UART0_FBRD: u64 = 0x28; // Fractional baud rate divisor
-#[allow(dead_code)]
 pub const UART0_LCRH: u64 = 0x2c; // Line control register
-#[allow(dead_code)]
 pub const UART0_CR: u64 = 0x30; // Control register
-#[allow(dead_code)]
 pub const UART0_IMSC: u64 = 0x38; // Interrupt mask set clear register
-#[allow(dead_code)]
 pub const UART0_ICR: u64 = 0x44; // Interrupt clear register
 
 // AUX registers, offset from aux_reg
-#[allow(dead_code)]
 pub const AUX_ENABLE: u64 = 0x04; // AUX enable register (Mini Uart, SPIs)
 
 // UART1 registers, offset from miniuart_reg
 pub const AUX_MU_IO: u64 = 0x00; // AUX IO data register
-#[allow(dead_code)]
 pub const AUX_MU_IER: u64 = 0x04; // Mini Uart interrupt enable register
-#[allow(dead_code)]
 pub const AUX_MU_IIR: u64 = 0x08; // Mini Uart interrupt identify register
-#[allow(dead_code)]
 pub const AUX_MU_LCR: u64 = 0x0c; // Mini Uart line control register
-#[allow(dead_code)]
 pub const AUX_MU_MCR: u64 = 0x10; // Mini Uart line control register
 pub const AUX_MU_LSR: u64 = 0x14; // Mini Uart line status register
-#[allow(dead_code)]
 pub const AUX_MU_CNTL: u64 = 0x20; // Mini Uart control register
-#[allow(dead_code)]
 pub const AUX_MU_BAUD: u64 = 0x28; // Mini Uart baudrate register
 
 bitstruct! {
@@ -190,7 +174,6 @@ bitstruct! {
     }
 }
 
-#[allow(dead_code)]
 impl EsrEl1IssInstructionAbort {
     pub fn from_esr_el1(r: EsrEl1) -> Option<EsrEl1IssInstructionAbort> {
         r.exception_class_enum()

--- a/aarch64/src/uartmini.rs
+++ b/aarch64/src/uartmini.rs
@@ -10,12 +10,14 @@ use crate::registers::{
 /// MiniUart is assigned to UART1 on the Raspberry Pi.  It is easier to use with
 /// real hardware, as it requires no additional configuration.  Conversely, it's
 /// harded to use with QEMU, as it can't be used with the `nographic` switch.
+#[allow(dead_code)]
 pub struct MiniUart {
     gpio_reg: RegBlock,
     aux_reg: RegBlock,
     miniuart_reg: RegBlock,
 }
 
+#[allow(dead_code)]
 impl MiniUart {
     pub fn new(dt: &DeviceTree, mmio_virt_offset: u64) -> MiniUart {
         // TODO use aliases?

--- a/aarch64/src/uartpl011.rs
+++ b/aarch64/src/uartpl011.rs
@@ -7,6 +7,7 @@ use crate::registers::{
 use port::devcons::Uart;
 use port::fdt::{DeviceTree, RegBlock};
 
+#[allow(dead_code)]
 pub struct Pl011Uart {
     gpio_reg: RegBlock,
     pl011_reg: RegBlock,
@@ -15,6 +16,7 @@ pub struct Pl011Uart {
 /// PL011 is the default in qemu (UART0), but a bit fiddly to use on a real
 /// Raspberry Pi board, as it needs additional configuration in the config
 /// and EEPROM (rpi4) to assign to the serial GPIO pins.
+#[allow(dead_code)]
 impl Pl011Uart {
     pub fn new(dt: &DeviceTree) -> Pl011Uart {
         // TODO use aliases?

--- a/riscv64/src/uart16550.rs
+++ b/riscv64/src/uart16550.rs
@@ -56,6 +56,7 @@ impl Uart16550 {
         }
     }
 
+    #[allow(dead_code)]
     pub fn get(&mut self) -> Option<u8> {
         let ptr = self.ns16550a_reg.addr as *mut u8;
         unsafe {


### PR DESCRIPTION
This is noisy, but once we should be able to tidy up in the future.  For now it's useful to have no warnings and have clearer error messages.