### PR TITLE
Add + use PhysAddr and VirtRange structs

### DIFF
--- a/aarch64/src/devcons.rs
+++ b/aarch64/src/devcons.rs
@@ -35,10 +35,9 @@ use port::mem::VirtRange;
 pub fn init(_dt: &DeviceTree) {
     Console::new(|| {
         let mmio = rpi_mmio().expect("mmio base detect failed").to_virt();
-
-        let gpio_range = VirtRange(mmio + 0x20_0000..mmio + 0x20_00b4);
-        let aux_range = VirtRange(mmio + 0x21_5000..mmio + 0x21_5008);
-        let miniuart_range = VirtRange(mmio + 0x21_5040..mmio + 0x21_5080);
+        let gpio_range = VirtRange::with_len(mmio + 0x20_0000, 0xb4);
+        let aux_range = VirtRange::with_len(mmio + 0x21_5000, 0x8);
+        let miniuart_range = VirtRange::with_len(mmio + 0x21_5040, 0x40);
 
         let uart = MiniUart { gpio_range, aux_range, miniuart_range };
         //let uart = MiniUart::new(dt);

--- a/aarch64/src/io.rs
+++ b/aarch64/src/io.rs
@@ -1,5 +1,5 @@
 use core::ptr::{read_volatile, write_volatile};
-use port::fdt::RegBlock;
+use port::mem::VirtRange;
 
 #[allow(dead_code)]
 pub enum GpioPull {
@@ -18,9 +18,8 @@ pub fn delay(count: u32) {
 
 /// Write val into the reg RegBlock at offset from reg.addr.
 /// Panics if offset is outside any range specified by reg.len.
-pub fn write_reg(reg: RegBlock, offset: u64, val: u32) {
-    let dst = reg.addr + offset;
-    assert!(reg.len.map_or(true, |len| offset < len));
+pub fn write_reg(range: &VirtRange, offset: usize, val: u32) {
+    let dst = range.offset_addr(offset).expect("offset outside bounds");
     unsafe { write_volatile(dst as *mut u32, val) }
 }
 
@@ -28,9 +27,8 @@ pub fn write_reg(reg: RegBlock, offset: u64, val: u32) {
 /// where `old` is the existing value.
 /// Panics if offset is outside any range specified by reg.len.
 #[allow(dead_code)]
-pub fn write_or_reg(reg: RegBlock, offset: u64, val: u32) {
-    let dst = reg.addr + offset;
-    assert!(reg.len.map_or(true, |len| offset < len));
+pub fn write_or_reg(range: &VirtRange, offset: usize, val: u32) {
+    let dst = range.offset_addr(offset).expect("offset outside bounds");
     unsafe {
         let old = read_volatile(dst as *const u32);
         write_volatile(dst as *mut u32, val | old)
@@ -39,8 +37,7 @@ pub fn write_or_reg(reg: RegBlock, offset: u64, val: u32) {
 
 /// Read from the reg RegBlock at offset from reg.addr.
 /// Panics if offset is outside any range specified by reg.len.
-pub fn read_reg(reg: RegBlock, offset: u64) -> u32 {
-    let src = reg.addr + offset;
-    assert!(reg.len.map_or(true, |len| offset < len));
+pub fn read_reg(range: &VirtRange, offset: usize) -> u32 {
+    let src = range.offset_addr(offset).expect("offset outside bounds");
     unsafe { read_volatile(src as *const u32) }
 }

--- a/aarch64/src/main.rs
+++ b/aarch64/src/main.rs
@@ -1,14 +1,16 @@
+#![allow(clippy::upper_case_acronyms)]
+#![cfg_attr(not(any(test, feature = "cargo-clippy")), no_std)]
+#![cfg_attr(not(test), no_main)]
 #![feature(alloc_error_handler)]
 #![feature(asm_const)]
 #![feature(stdsimd)]
-#![cfg_attr(not(any(test, feature = "cargo-clippy")), no_std)]
-#![cfg_attr(not(test), no_main)]
-#![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 
 mod devcons;
 mod io;
 mod mailbox;
+mod mem;
+mod param;
 mod registers;
 mod trap;
 mod uartmini;

--- a/aarch64/src/mem.rs
+++ b/aarch64/src/mem.rs
@@ -1,5 +1,6 @@
 use crate::param::KZERO;
 
+#[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct PhysAddr(u64);
 

--- a/aarch64/src/mem.rs
+++ b/aarch64/src/mem.rs
@@ -4,13 +4,11 @@ use crate::param::KZERO;
 pub struct PhysAddr(u64);
 
 impl PhysAddr {
+    pub fn new(value: u64) -> Self {
+        PhysAddr(value)
+    }
+
     pub fn to_virt(&self) -> usize {
         (self.0 as usize).wrapping_add(KZERO)
-    }
-}
-
-impl From<usize> for PhysAddr {
-    fn from(value: usize) -> Self {
-        PhysAddr(value as u64)
     }
 }

--- a/aarch64/src/mem.rs
+++ b/aarch64/src/mem.rs
@@ -1,0 +1,16 @@
+use crate::param::KZERO;
+
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct PhysAddr(u64);
+
+impl PhysAddr {
+    pub fn to_virt(&self) -> usize {
+        (self.0 as usize).wrapping_add(KZERO)
+    }
+}
+
+impl From<usize> for PhysAddr {
+    fn from(value: usize) -> Self {
+        PhysAddr(value as u64)
+    }
+}

--- a/aarch64/src/param.rs
+++ b/aarch64/src/param.rs
@@ -1,0 +1,2 @@
+// This needs to match KZERO in l.S
+pub const KZERO: usize = 0xffff_8000_0000_0000;

--- a/aarch64/src/registers.rs
+++ b/aarch64/src/registers.rs
@@ -94,9 +94,9 @@ impl PartNum {
     /// Return the physical MMIO base address for the Raspberry Pi MMIO
     pub fn mmio(&self) -> Option<PhysAddr> {
         match self {
-            Self::RaspberryPi1 => Some(PhysAddr::from(0x20000000)),
-            Self::RaspberryPi2 | Self::RaspberryPi3 => Some(PhysAddr::from(0x3f000000)),
-            Self::RaspberryPi4 => Some(PhysAddr::from(0xfe000000)),
+            Self::RaspberryPi1 => Some(PhysAddr::new(0x20000000)),
+            Self::RaspberryPi2 | Self::RaspberryPi3 => Some(PhysAddr::new(0x3f000000)),
+            Self::RaspberryPi4 => Some(PhysAddr::new(0xfe000000)),
             Self::Unknown => None,
         }
     }

--- a/aarch64/src/registers.rs
+++ b/aarch64/src/registers.rs
@@ -4,33 +4,35 @@ use bitstruct::bitstruct;
 use core::fmt;
 use num_enum::TryFromPrimitive;
 
+use crate::mem::PhysAddr;
+
 // GPIO registers
-pub const GPFSEL1: u64 = 0x04; // GPIO function select register 1
-pub const GPPUD: u64 = 0x94; // GPIO pin pull up/down enable
-pub const GPPUDCLK0: u64 = 0x98; // GPIO pin pull up/down enable clock 0
+pub const GPFSEL1: usize = 0x04; // GPIO function select register 1
+pub const GPPUD: usize = 0x94; // GPIO pin pull up/down enable
+pub const GPPUDCLK0: usize = 0x98; // GPIO pin pull up/down enable clock 0
 
 // UART 0 (PL011) registers
-pub const UART0_DR: u64 = 0x00; // Data register
-pub const UART0_FR: u64 = 0x18; // Flag register
-pub const UART0_IBRD: u64 = 0x24; // Integer baud rate divisor
-pub const UART0_FBRD: u64 = 0x28; // Fractional baud rate divisor
-pub const UART0_LCRH: u64 = 0x2c; // Line control register
-pub const UART0_CR: u64 = 0x30; // Control register
-pub const UART0_IMSC: u64 = 0x38; // Interrupt mask set clear register
-pub const UART0_ICR: u64 = 0x44; // Interrupt clear register
+pub const UART0_DR: usize = 0x00; // Data register
+pub const UART0_FR: usize = 0x18; // Flag register
+pub const UART0_IBRD: usize = 0x24; // Integer baud rate divisor
+pub const UART0_FBRD: usize = 0x28; // Fractional baud rate divisor
+pub const UART0_LCRH: usize = 0x2c; // Line control register
+pub const UART0_CR: usize = 0x30; // Control register
+pub const UART0_IMSC: usize = 0x38; // Interrupt mask set clear register
+pub const UART0_ICR: usize = 0x44; // Interrupt clear register
 
 // AUX registers, offset from aux_reg
-pub const AUX_ENABLE: u64 = 0x04; // AUX enable register (Mini Uart, SPIs)
+pub const AUX_ENABLE: usize = 0x04; // AUX enable register (Mini Uart, SPIs)
 
 // UART1 registers, offset from miniuart_reg
-pub const AUX_MU_IO: u64 = 0x00; // AUX IO data register
-pub const AUX_MU_IER: u64 = 0x04; // Mini Uart interrupt enable register
-pub const AUX_MU_IIR: u64 = 0x08; // Mini Uart interrupt identify register
-pub const AUX_MU_LCR: u64 = 0x0c; // Mini Uart line control register
-pub const AUX_MU_MCR: u64 = 0x10; // Mini Uart line control register
-pub const AUX_MU_LSR: u64 = 0x14; // Mini Uart line status register
-pub const AUX_MU_CNTL: u64 = 0x20; // Mini Uart control register
-pub const AUX_MU_BAUD: u64 = 0x28; // Mini Uart baudrate register
+pub const AUX_MU_IO: usize = 0x00; // AUX IO data register
+pub const AUX_MU_IER: usize = 0x04; // Mini Uart interrupt enable register
+pub const AUX_MU_IIR: usize = 0x08; // Mini Uart interrupt identify register
+pub const AUX_MU_LCR: usize = 0x0c; // Mini Uart line control register
+pub const AUX_MU_MCR: usize = 0x10; // Mini Uart line control register
+pub const AUX_MU_LSR: usize = 0x14; // Mini Uart line status register
+pub const AUX_MU_CNTL: usize = 0x20; // Mini Uart control register
+pub const AUX_MU_BAUD: usize = 0x28; // Mini Uart baudrate register
 
 bitstruct! {
     #[derive(Copy, Clone)]
@@ -90,14 +92,18 @@ pub enum PartNum {
 
 impl PartNum {
     /// Return the physical MMIO base address for the Raspberry Pi MMIO
-    pub fn mmio(&self) -> u64 {
+    pub fn mmio(&self) -> Option<PhysAddr> {
         match self {
-            Self::RaspberryPi1 => 0x20000000,
-            Self::RaspberryPi2 | Self::RaspberryPi3 => 0x3f000000,
-            Self::RaspberryPi4 => 0xfe000000,
-            Self::Unknown => 0,
+            Self::RaspberryPi1 => Some(PhysAddr::from(0x20000000)),
+            Self::RaspberryPi2 | Self::RaspberryPi3 => Some(PhysAddr::from(0x3f000000)),
+            Self::RaspberryPi4 => Some(PhysAddr::from(0xfe000000)),
+            Self::Unknown => None,
         }
     }
+}
+
+pub fn rpi_mmio() -> Option<PhysAddr> {
+    MidrEl1::read().partnum_enum().ok().and_then(|p| p.mmio())
 }
 
 bitstruct! {

--- a/aarch64/src/runtime.rs
+++ b/aarch64/src/runtime.rs
@@ -18,9 +18,9 @@ use port::mem::VirtRange;
 pub extern "C" fn panic(info: &PanicInfo) -> ! {
     let mmio = rpi_mmio().expect("mmio base detect failed").to_virt();
 
-    let gpio_range = VirtRange((mmio + 0x200000)..(mmio + 0x20_00b4));
-    let aux_range = VirtRange((mmio + 0x215000)..(mmio + 0x21_5008));
-    let miniuart_range = VirtRange((mmio + 0x215040)..(mmio + 0x21_5080));
+    let gpio_range = VirtRange::with_len(mmio + 0x200000, 0xb4);
+    let aux_range = VirtRange::with_len(mmio + 0x215000, 0x8);
+    let miniuart_range = VirtRange::with_len(mmio + 0x215040, 0x40);
 
     let uart = MiniUart { gpio_range, aux_range, miniuart_range };
     //uart.init();

--- a/aarch64/src/uartmini.rs
+++ b/aarch64/src/uartmini.rs
@@ -1,5 +1,6 @@
 use port::devcons::Uart;
-use port::fdt::{DeviceTree, RegBlock};
+use port::fdt::DeviceTree;
+use port::mem::VirtRange;
 
 use crate::io::{delay, read_reg, write_or_reg, write_reg};
 use crate::registers::{
@@ -12,77 +13,72 @@ use crate::registers::{
 /// harded to use with QEMU, as it can't be used with the `nographic` switch.
 #[allow(dead_code)]
 pub struct MiniUart {
-    gpio_reg: RegBlock,
-    aux_reg: RegBlock,
-    miniuart_reg: RegBlock,
+    pub gpio_range: VirtRange,
+    pub aux_range: VirtRange,
+    pub miniuart_range: VirtRange,
 }
 
 #[allow(dead_code)]
 impl MiniUart {
     pub fn new(dt: &DeviceTree, mmio_virt_offset: u64) -> MiniUart {
         // TODO use aliases?
-        let gpio_reg = dt
-            .find_compatible("brcm,bcm2835-gpio")
-            .next()
-            .and_then(|uart| dt.property_translated_reg_iter(uart).next())
-            .and_then(|reg| reg.regblock())
-            .unwrap()
-            .with_offset(mmio_virt_offset);
+        let gpio_range = VirtRange::from(
+            &dt.find_compatible("brcm,bcm2835-gpio")
+                .next()
+                .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+                .and_then(|reg| reg.regblock())
+                .unwrap()
+                .with_offset(mmio_virt_offset),
+        );
 
         // Find a compatible aux
-        let aux_reg = dt
-            .find_compatible("brcm,bcm2835-aux")
-            .next()
-            .and_then(|uart| dt.property_translated_reg_iter(uart).next())
-            .and_then(|reg| reg.regblock())
-            .unwrap()
-            .with_offset(mmio_virt_offset);
+        let aux_range = VirtRange::from(
+            &dt.find_compatible("brcm,bcm2835-aux")
+                .next()
+                .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+                .and_then(|reg| reg.regblock())
+                .unwrap()
+                .with_offset(mmio_virt_offset),
+        );
 
         // Find a compatible miniuart
-        let miniuart_reg = dt
-            .find_compatible("brcm,bcm2835-aux-uart")
-            .next()
-            .and_then(|uart| dt.property_translated_reg_iter(uart).next())
-            .and_then(|reg| reg.regblock())
-            .unwrap()
-            .with_offset(mmio_virt_offset);
+        let miniuart_range = VirtRange::from(
+            &dt.find_compatible("brcm,bcm2835-aux-uart")
+                .next()
+                .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+                .and_then(|reg| reg.regblock())
+                .unwrap()
+                .with_offset(mmio_virt_offset),
+        );
 
-        MiniUart { gpio_reg, aux_reg, miniuart_reg }
-    }
-
-    pub fn from_addresses(gpio_addr: u64, aux_addr: u64, miniuart_addr: u64) -> MiniUart {
-        MiniUart {
-            gpio_reg: RegBlock::from_addr(gpio_addr),
-            aux_reg: RegBlock::from_addr(aux_addr),
-            miniuart_reg: RegBlock::from_addr(miniuart_addr),
-        }
+        MiniUart { gpio_range, aux_range, miniuart_range }
     }
 
     pub fn init(&self) {
         // Set GPIO pins 14 and 15 to be used for UART1.  This is done by
         // setting the appropriate flags in GPFSEL1 to ALT5, which is
         // represented by the 0b010
-        let mut gpfsel1 = read_reg(self.gpio_reg, GPFSEL1);
+        let mut gpfsel1 = read_reg(&self.gpio_range, GPFSEL1);
         gpfsel1 &= !((7 << 12) | (7 << 15));
         gpfsel1 |= (2 << 12) | (2 << 15);
-        write_reg(self.gpio_reg, GPFSEL1, gpfsel1);
+        write_reg(&self.gpio_range, GPFSEL1, gpfsel1);
 
-        write_reg(self.gpio_reg, GPPUD, 0);
+        write_reg(&self.gpio_range, GPPUD, 0);
         delay(150);
-        write_reg(self.gpio_reg, GPPUDCLK0, (1 << 14) | (1 << 15));
+        write_reg(&self.gpio_range, GPPUDCLK0, (1 << 14) | (1 << 15));
         delay(150);
-        write_reg(self.gpio_reg, GPPUDCLK0, 0);
+        write_reg(&self.gpio_range, GPPUDCLK0, 0);
 
         // Enable mini uart - required to write to its registers
-        write_or_reg(self.aux_reg, AUX_ENABLE, 1);
-        write_reg(self.miniuart_reg, AUX_MU_CNTL, 0);
+        write_or_reg(&self.aux_range, AUX_ENABLE, 1);
+        write_reg(&self.miniuart_range, AUX_MU_CNTL, 0);
         // 8-bit
-        write_reg(self.miniuart_reg, AUX_MU_LCR, 3);
-        write_reg(self.miniuart_reg, AUX_MU_MCR, 0);
+        write_reg(&self.miniuart_range, AUX_MU_LCR, 3);
+        write_reg(&self.miniuart_range, AUX_MU_MCR, 0);
         // Disable interrupts
-        write_reg(self.miniuart_reg, AUX_MU_IER, 0);
+        write_reg(&self.miniuart_range, AUX_MU_IER, 0);
         // Clear receive/transmit FIFOs
-        write_reg(self.miniuart_reg, AUX_MU_IIR, 0xc6);
+        write_reg(&self.miniuart_range, AUX_MU_IIR, 0xc6);
 
         // We want 115200 baud.  This is calculated as:
         //   system_clock_freq / (8 * (baudrate_reg + 1))
@@ -91,19 +87,19 @@ impl MiniUart {
         // let arm_clock_rate = 500000000.0;
         // let baud_rate_reg = arm_clock_rate / (8.0 * 115200.0) + 1.0;
         //write_reg(self.miniuart_reg, AUX_MU_BAUD, baud_rate_reg as u32);
-        write_reg(self.miniuart_reg, AUX_MU_BAUD, 270);
+        write_reg(&self.miniuart_range, AUX_MU_BAUD, 270);
 
         // Finally enable transmit
-        write_reg(self.miniuart_reg, AUX_MU_CNTL, 3);
+        write_reg(&self.miniuart_range, AUX_MU_CNTL, 3);
     }
 }
 
 impl Uart for MiniUart {
     fn putb(&self, b: u8) {
         // Wait for UART to become ready to transmit
-        while read_reg(self.miniuart_reg, AUX_MU_LSR) & (1 << 5) == 0 {
+        while read_reg(&self.miniuart_range, AUX_MU_LSR) & (1 << 5) == 0 {
             core::hint::spin_loop();
         }
-        write_reg(self.miniuart_reg, AUX_MU_IO, b as u32);
+        write_reg(&self.miniuart_range, AUX_MU_IO, b as u32);
     }
 }

--- a/port/src/lib.rs
+++ b/port/src/lib.rs
@@ -7,3 +7,4 @@ pub mod dat;
 pub mod devcons;
 pub mod fdt;
 pub mod mcslock;
+pub mod mem;

--- a/port/src/mem.rs
+++ b/port/src/mem.rs
@@ -1,0 +1,23 @@
+use crate::fdt::RegBlock;
+use core::ops::Range;
+
+pub struct VirtRange(pub Range<usize>);
+
+impl VirtRange {
+    pub fn offset_addr(&self, offset: usize) -> Option<usize> {
+        let addr = self.0.start + offset;
+        if self.0.contains(&addr) {
+            Some(addr)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<&RegBlock> for VirtRange {
+    fn from(r: &RegBlock) -> Self {
+        let start = r.addr as usize;
+        let end = start + r.len.unwrap_or(0) as usize;
+        VirtRange(start..end)
+    }
+}

--- a/port/src/mem.rs
+++ b/port/src/mem.rs
@@ -4,6 +4,10 @@ use core::ops::Range;
 pub struct VirtRange(pub Range<usize>);
 
 impl VirtRange {
+    pub fn with_len(start: usize, len: usize) -> Self {
+        Self(start..start + len)
+    }
+
     pub fn offset_addr(&self, offset: usize) -> Option<usize> {
         let addr = self.0.start + offset;
         if self.0.contains(&addr) {


### PR DESCRIPTION
We want to use a PhysAddr struct, so start using it for existing code first.  Also adds a VirtAddr struct to represent a virtual address range.