### PR TITLE
Ensure `cargo check` works for the workspace without flags

### DIFF
--- a/aarch64/Cargo.toml
+++ b/aarch64/Cargo.toml
@@ -1,7 +1,10 @@
+cargo-features = ["per-package-target"]
+
 [package]
 name = "aarch64"
 version = "0.1.0"
 edition = "2021"
+default-target = "aarch64-unknown-none-softfloat"
 
 [dependencies]
 bitstruct = "0.1"

--- a/riscv64/Cargo.toml
+++ b/riscv64/Cargo.toml
@@ -1,7 +1,10 @@
+cargo-features = ["per-package-target"]
+
 [package]
 name = "riscv64"
 version = "0.1.0"
 edition = "2021"
+default-target = "riscv64imac-unknown-none-elf"
 
 [dependencies]
 port = { path = "../port" }

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -1,7 +1,10 @@
+cargo-features = ["per-package-target"]
+
 [package]
 name = "x86_64"
 version = "0.1.0"
 edition = "2021"
+default-target = "x86_64-unknown-none"
 
 [dependencies]
 bitstruct = "0.1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -397,6 +397,7 @@ fn test(build_params: &BuildParams) -> Result<()> {
     cmd.current_dir(workspace());
     cmd.arg("test");
     cmd.arg("--workspace");
+    cmd.arg("--target").arg("x86_64-unknown-linux-gnu");
     cmd.arg("--config").arg("build.rustflags='--cfg platform=\"virt\"'");
     build_params.add_build_arg(&mut cmd);
     if build_params.verbose {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -398,7 +398,6 @@ fn test(build_params: &BuildParams) -> Result<()> {
     cmd.arg("test");
     cmd.arg("--workspace");
     cmd.arg("--target").arg("x86_64-unknown-linux-gnu");
-    cmd.arg("--config").arg("build.rustflags='--cfg platform=\"virt\"'");
     build_params.add_build_arg(&mut cmd);
     if build_params.verbose {
         println!("Executing {cmd:?}");


### PR DESCRIPTION
This makes sure we check the platform specific crates using the correct architecture.

See https://github.com/rust-lang/cargo/pull/9030 for the unstable cargo feature.