### PR TITLE
cargo check uses xtask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "git.alwaysSignOff": true,
+    "rust-analyzer.check.overrideCommand": [
+        "cargo",
+        "xtask",
+        "check",
+        "--json"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ Right now, r9 is not self-hosting.
 
 `cargo xtask dist`, which `cargo xtask qemu` and 
 `cargo xtask qemukvm` depend on, requires `llvm-objcopy`. 
-This is expected to live in the rust toolchain path. If 
-you get `No such file or directory (os error 2)` messages, 
+This is expected to live in the rust toolchain path.  You can install by running:
+```
+rustup component add llvm-tools
+```
+
+If you get `No such file or directory (os error 2)` messages, 
 then install `llvm` separate from the rust toolchain and set:
 ```
 OBJCOPY=$(which llvm-objcopy) cargo xtask qemukvm

--- a/aarch64/Cargo.toml
+++ b/aarch64/Cargo.toml
@@ -4,7 +4,7 @@ cargo-features = ["per-package-target"]
 name = "aarch64"
 version = "0.1.0"
 edition = "2021"
-default-target = "aarch64-unknown-none-softfloat"
+default-target = "aarch64-unknown-none"
 
 [dependencies]
 bitstruct = "0.1"

--- a/aarch64/src/runtime.rs
+++ b/aarch64/src/runtime.rs
@@ -15,7 +15,7 @@ use port::mem::VirtRange;
 //  - Use Console via println!() macro once available
 //  - Add support for raspi4
 #[panic_handler]
-pub extern "C" fn panic(info: &PanicInfo) -> ! {
+pub fn panic(info: &PanicInfo) -> ! {
     let mmio = rpi_mmio().expect("mmio base detect failed").to_virt();
 
     let gpio_range = VirtRange::with_len(mmio + 0x200000, 0xb4);

--- a/aarch64/src/trap.S
+++ b/aarch64/src/trap.S
@@ -99,6 +99,7 @@
 /// Each entry is 16 instructions/128 bytes.
 /// Ventry handles alignment of individual entries.
 .balign	2048
+.globl exception_vectors
 exception_vectors:
 	// Current EL with SP0
 	ventry	sync_invalid_el1t			// Synchronous EL1t

--- a/riscv64/src/sbi.rs
+++ b/riscv64/src/sbi.rs
@@ -2,7 +2,7 @@
 //!
 //! Chapter 5: Legacy Extensions
 
-#![cfg_attr(not(target_arch = "riscv64"), allow(dead_code))]
+#![allow(dead_code)]
 
 const SBI_SET_TIMER: usize = 0;
 const SBI_CONSOLE_PUTCHAR: usize = 1;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 channel = "nightly-2023-06-05"
 components = [ "rustfmt", "rust-src", "clippy", "llvm-tools" ]
 targets = [
-  "aarch64-unknown-none-softfloat",
+  "aarch64-unknown-none",
   "riscv64imac-unknown-none-elf",
   "x86_64-unknown-none"
 ]

--- a/x86_64/src/runtime.rs
+++ b/x86_64/src/runtime.rs
@@ -6,7 +6,7 @@ use alloc::alloc::{GlobalAlloc, Layout};
 use core::panic::PanicInfo;
 
 #[panic_handler]
-pub extern "C" fn panic(_info: &PanicInfo) -> ! {
+pub fn panic(_info: &PanicInfo) -> ! {
     #[allow(clippy::empty_loop)]
     loop {}
 }


### PR DESCRIPTION
Various build improvements:
- Add support for `cargo xtask check`
- Add .vscode/settings.json to have rust-analyzer use `cargo xtask check`
- Minor code changes to fix build with latest nightly and remove some errors
- Change aarch64 target to aarch64-unknown-none (from aarch64-unknown-none-softfloat)