### PR TITLE
Implement thorough check and test in xtask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustup-configurator"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ea4d26348e7916570c4cc67014aad9e017f148cd5bb8a4ee0f5b95f2db788d"
+dependencies = [
+ "strip-ansi-escapes",
+ "target-lexicon",
+ "thiserror",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +320,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -347,6 +396,26 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "windows-sys"
@@ -448,6 +517,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "rustup-configurator",
  "serde",
  "toml",
 ]

--- a/riscv64/Cargo.toml
+++ b/riscv64/Cargo.toml
@@ -4,7 +4,7 @@ cargo-features = ["per-package-target"]
 name = "riscv64"
 version = "0.1.0"
 edition = "2021"
-default-target = "riscv64imac-unknown-none-elf"
+default-target = "riscv64gc-unknown-none-elf"
 
 [dependencies]
 port = { path = "../port" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@ channel = "nightly-2023-06-05"
 components = [ "rustfmt", "rust-src", "clippy", "llvm-tools" ]
 targets = [
   "aarch64-unknown-none",
-  "riscv64imac-unknown-none-elf",
+  "riscv64gc-unknown-none-elf",
   "x86_64-unknown-none"
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.2.4", features = ["derive"] }
+rustup-configurator = "0.1.1"
 serde = { version = "1.0.160", features = ["derive"] }
 toml = "0.8.0"


### PR DESCRIPTION
`cargo xtask check` depends on having installed `<arch>-unknown-linux-gnu` for each supported arch via `rustup`, otherwise the relevant check is not run.

Also changes the riscv target from riscvimac to riscvgc so that we have better toolchain support.

Github actions runs the x86-64 tests.  If it ever supports aarch64 or riscv64 runners, we could also have it run these tests.