### PR TITLE
Restructure xtask, fix flag parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,17 +246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustup-configurator"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ea4d26348e7916570c4cc67014aad9e017f148cd5bb8a4ee0f5b95f2db788d"
-dependencies = [
- "strip-ansi-escapes",
- "target-lexicon",
- "thiserror",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,15 +272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "strip-ansi-escapes"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
-dependencies = [
- "vte",
 ]
 
 [[package]]
@@ -327,29 +307,6 @@ name = "target-lexicon"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
-]
 
 [[package]]
 name = "toml"
@@ -396,26 +353,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vte"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
-dependencies = [
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "windows-sys"
@@ -517,7 +454,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "clap",
- "rustup-configurator",
  "serde",
+ "target-lexicon",
  "toml",
 ]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Right now, r9 is not self-hosting.
 
 ## Runtime Dependencies
 
-`cargo xtask dist`, which `cargo xtask qemu` and 
-`cargo xtask qemukvm` depend on, requires `llvm-objcopy`. 
+`cargo xtask dist`, which `cargo xtask qemu` depends on, requires `llvm-objcopy`. 
 This is expected to live in the rust toolchain path.  You can install by running:
 ```
 rustup component add llvm-tools
@@ -47,6 +46,7 @@ R9 can be run using qemu for the various supported architectures:
 |----|-----------|
 |aarch64|cargo xtask qemu --arch aarch64 --verbose|
 |x86-64|cargo xtask qemu --arch x86-64 --verbose|
+|x86-64 (with kvm)|cargo xtask qemu --arch x86-64 --kvm --verbose|
 |riscv|cargo xtask qemu --arch riscv64 --verbose|
 
 ## Running on Real Hardware™️

--- a/aarch64/src/kmem.rs
+++ b/aarch64/src/kmem.rs
@@ -50,7 +50,7 @@ pub fn eearly_pagetables_addr() -> usize {
     unsafe { eearly_pagetables.as_ptr().addr() }
 }
 
-#[derive(Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(transparent)]
 pub struct PhysAddr(u64);
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.2.4", features = ["derive"] }
-rustup-configurator = "0.1.1"
 serde = { version = "1.0.160", features = ["derive"] }
+target-lexicon = { version = "0.12" }
 toml = "0.8.0"

--- a/xtask/src/config.rs
+++ b/xtask/src/config.rs
@@ -75,23 +75,25 @@ pub struct Configuration {
     pub link: Option<HashMap<String, String>>,
 }
 
-pub fn read_config(filename: String) -> Configuration {
-    let contents = match fs::read_to_string(filename.clone()) {
-        Ok(c) => c,
-        Err(_) => {
-            eprintln!("Could not read file `{filename}`");
-            exit(1);
-        }
-    };
-    let config: Configuration = match toml::from_str(&contents) {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("TOML: Unable to load data from `{}`", filename);
-            eprintln!("{e}");
-            exit(1);
-        }
-    };
-    config
+impl Configuration {
+    pub fn load(filename: String) -> Self {
+        let contents = match fs::read_to_string(filename.clone()) {
+            Ok(c) => c,
+            Err(_) => {
+                eprintln!("Could not read file `{filename}`");
+                exit(1);
+            }
+        };
+        let config: Configuration = match toml::from_str(&contents) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("TOML: Unable to load data from `{}`", filename);
+                eprintln!("{e}");
+                exit(1);
+            }
+        };
+        config
+    }
 }
 
 /// task could be 'build', 'clippy'

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-use crate::config::{generate_args, read_config, Configuration};
+use crate::config::{generate_args, Configuration};
 use rustup_configurator::Triple;
 use std::{
     env, fmt,
@@ -11,10 +11,27 @@ mod config;
 type DynError = Box<dyn std::error::Error>;
 type Result<T> = std::result::Result<T, DynError>;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Profile {
     Debug,
     Release,
+}
+
+impl Profile {
+    fn from(matches: &clap::ArgMatches) -> Self {
+        if matches.get_flag("release") {
+            Profile::Release
+        } else {
+            Profile::Debug
+        }
+    }
+
+    fn dir(&self) -> &'static str {
+        match self {
+            Profile::Debug => "debug",
+            Profile::Release => "release",
+        }
+    }
 }
 
 impl fmt::Display for Profile {
@@ -30,84 +47,30 @@ enum Arch {
     X86_64,
 }
 
-impl fmt::Display for Arch {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-// TODO This is becoming a bag of random fields - maybe turn into an enum
-struct BuildParams {
-    arch: Arch,
-    profile: Profile,
-    verbose: bool,
-    wait_for_gdb: bool,
-    config: Configuration,
-    dump_dtb: String,
-    json_output: bool,
-}
-
-impl BuildParams {
-    fn new(matches: &clap::ArgMatches) -> Self {
-        let profile = if matches.try_contains_id("release").unwrap_or(false) {
-            Profile::Release
-        } else {
-            Profile::Debug
-        };
-        let verbose = matches.get_flag("verbose");
-        let arch = matches.try_get_one("arch").ok().flatten().unwrap_or(&Arch::X86_64);
-        let wait_for_gdb =
-            matches.try_contains_id("gdb").unwrap_or(false) && matches.get_flag("gdb");
-
-        let dump_dtb: String = matches
-            .try_get_one::<String>("dump_dtb")
-            .ok()
-            .flatten()
-            .unwrap_or(&"".to_string())
-            .clone();
-        let default = "default".to_string();
-        let config_file = matches.try_get_one("config").ok().flatten().unwrap_or(&default);
-        let config = read_config(format!(
-            "{}/{}/lib/config_{}.toml",
-            workspace().display(),
-            arch.to_string().to_lowercase(),
-            config_file
-        ));
-
-        // This is a very awkward way to check a boolean which may not exist...
-        let json_output = matches.try_contains_id("json").unwrap_or(false)
-            && matches.value_source("json") != Some(clap::parser::ValueSource::DefaultValue);
-
-        Self { arch: *arch, profile, verbose, wait_for_gdb, dump_dtb, config, json_output }
-    }
-
-    fn dir(&self) -> &'static str {
-        match self.profile {
-            Profile::Debug => "debug",
-            Profile::Release => "release",
-        }
-    }
-
-    fn add_build_arg(&self, cmd: &mut Command) {
-        if let Profile::Release = self.profile {
-            cmd.arg("--release");
-        }
+impl Arch {
+    fn from(matches: &clap::ArgMatches) -> Self {
+        *matches.get_one::<Arch>("arch").unwrap_or(&Arch::X86_64)
     }
 
     fn qemu_system(&self) -> String {
-        let defaultqemu = match self.arch {
-            Arch::Aarch64 => "qemu-system-aarch64",
-            Arch::Riscv64 => "qemu-system-riscv64",
-            Arch::X86_64 => "qemu-system-x86_64",
-        };
-        env_or("QEMU", defaultqemu)
+        env_or(
+            "QEMU",
+            match self {
+                Arch::Aarch64 => "qemu-system-aarch64",
+                Arch::Riscv64 => "qemu-system-riscv64",
+                Arch::X86_64 => "qemu-system-x86_64",
+            },
+        )
     }
 
     fn target(&self) -> String {
-        env_or(
-            "TARGET",
-            format!("{}-unknown-none-elf", self.arch.to_string().to_lowercase()).as_str(),
-        )
+        env_or("TARGET", format!("{}-unknown-none-elf", self.to_string().to_lowercase()).as_str())
+    }
+}
+
+impl fmt::Display for Arch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self:?}")
     }
 }
 
@@ -152,6 +115,7 @@ fn main() {
         .version("0.1.0")
         .author("The r9 Authors")
         .about("Build support for the r9 operating system")
+        .arg_required_else_help(true)
         .subcommand(
             clap::Command::new("build").about("Builds r9").args(&[
                 clap::arg!(--release "Build release version").conflicts_with("debug"),
@@ -197,6 +161,7 @@ fn main() {
         .subcommand(clap::Command::new("test").about("Runs unit tests").args(&[
             clap::arg!(--release "Build a release version").conflicts_with("debug"),
             clap::arg!(--debug "Build a debug version").conflicts_with("release"),
+            clap::arg!(--json "Output messages as json"),
             clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(
@@ -222,21 +187,10 @@ fn main() {
                 clap::arg!(--arch <arch> "Target architecture")
                     .value_parser(clap::builder::EnumValueParser::<Arch>::new()),
                 clap::arg!(--gdb "Wait for gdb connection on start"),
+                clap::arg!(--kvm "Run with KVM"),
                 clap::arg!(--config <name> "Configuration")
                     .value_parser(clap::builder::NonEmptyStringValueParser::new())
                     .default_value("default"),
-                clap::arg!(--verbose "Print commands"),
-                clap::arg!(--dump_dtb <file> "Dump the DTB from QEMU to a file")
-                    .value_parser(clap::value_parser!(String)),
-            ]),
-        )
-        .subcommand(
-            clap::Command::new("qemukvm").about("Run r9 under QEMU with KVM").args(&[
-                clap::arg!(--release "Build a release version").conflicts_with("debug"),
-                clap::arg!(--debug "Build a debug version").conflicts_with("release"),
-                clap::arg!(--arch <arch> "Target architecture")
-                    .value_parser(clap::builder::EnumValueParser::<Arch>::new()),
-                clap::arg!(--gdb "Wait for gdb connection on start"),
                 clap::arg!(--verbose "Print commands"),
                 clap::arg!(--dump_dtb <file> "Dump the DTB from QEMU to a file")
                     .value_parser(clap::value_parser!(String)),
@@ -246,16 +200,24 @@ fn main() {
         .get_matches();
 
     if let Err(e) = match matches.subcommand() {
-        Some(("build", m)) => build(&BuildParams::new(m)),
-        Some(("expand", m)) => expand(&BuildParams::new(m)),
-        Some(("kasm", m)) => kasm(&BuildParams::new(m)),
-        Some(("dist", m)) => dist(&BuildParams::new(m)),
-        Some(("test", m)) => test(&BuildParams::new(m)),
-        Some(("clippy", m)) => clippy(&BuildParams::new(m)),
-        Some(("check", m)) => check(&BuildParams::new(m)),
-        Some(("qemu", m)) => run(&BuildParams::new(m)),
-        Some(("qemukvm", m)) => accelrun(&BuildParams::new(m)),
-        Some(("clean", _)) => clean(),
+        Some(("build", m)) => BuildStep::new(m).run(),
+        Some(("expand", m)) => ExpandStep::new(m).run(),
+        Some(("kasm", m)) => KasmStep::new(m).run(),
+        Some(("dist", m)) => {
+            let s1 = BuildStep::new(m);
+            let s2 = DistStep::new(m);
+            s1.run().and_then(|_| s2.run())
+        }
+        Some(("test", m)) => TestStep::new(m).run(),
+        Some(("clippy", m)) => ClippyStep::new(m).run(),
+        Some(("check", m)) => CheckStep::new(m).run(),
+        Some(("qemu", m)) => {
+            let s1 = BuildStep::new(m);
+            let s2 = DistStep::new(m);
+            let s3 = QemuStep::new(m);
+            s1.run().and_then(|_| s2.run()).and_then(|_| s3.run())
+        }
+        Some(("clean", _)) => CleanStep::new().run(),
         _ => Err("bad subcommand".into()),
     } {
         eprintln!("{e}");
@@ -299,459 +261,603 @@ fn objcopy() -> String {
     env_or("OBJCOPY", &llvm_objcopy)
 }
 
-fn build(build_params: &BuildParams) -> Result<()> {
-    let mut cmd = generate_args(
-        "build",
-        &build_params.config,
-        &build_params.target(),
-        &build_params.profile,
-        workspace().to_str().unwrap(),
-    );
-    cmd.current_dir(workspace());
-    cmd.arg("--workspace");
-    cmd.arg("--exclude").arg("xtask");
-    exclude_other_arches(build_params.arch, &mut cmd);
-    build_params.add_build_arg(&mut cmd);
-    if build_params.verbose {
-        println!("Executing {cmd:?}");
-    }
-    let status = annotated_status(&mut cmd)?;
-    if !status.success() {
-        return Err("build kernel failed".into());
-    }
-    Ok(())
+fn load_config(arch: Arch, matches: &clap::ArgMatches) -> Configuration {
+    let default = "default".to_string();
+    let config_file = matches.try_get_one("config").ok().flatten().unwrap_or(&default);
+    Configuration::load(format!(
+        "{}/{}/lib/config_{}.toml",
+        workspace().display(),
+        arch.to_string().to_lowercase(),
+        config_file
+    ))
 }
 
-fn expand(build_params: &BuildParams) -> Result<()> {
-    let mut cmd = Command::new(cargo());
-    cmd.current_dir(workspace());
-    cmd.arg("rustc");
-    cmd.arg("-Z").arg("build-std=core,alloc");
-    cmd.arg("-p").arg(build_params.arch.to_string().to_lowercase());
-    cmd.arg("--target").arg(format!("lib/{}.json", build_params.target()));
-    cmd.arg("--");
-    cmd.arg("-Z").arg("unpretty=expanded");
-    build_params.add_build_arg(&mut cmd);
-    if build_params.verbose {
-        println!("Executing {cmd:?}");
-    }
-    let status = annotated_status(&mut cmd)?;
-    if !status.success() {
-        return Err("build kernel failed".into());
-    }
-    Ok(())
+fn verbose(matches: &clap::ArgMatches) -> bool {
+    matches.get_flag("verbose")
 }
 
-fn kasm(build_params: &BuildParams) -> Result<()> {
-    let mut cmd = Command::new(cargo());
-    cmd.current_dir(workspace());
-    cmd.arg("rustc");
-    cmd.arg("-Z").arg("build-std=core,alloc");
-    cmd.arg("-p").arg(build_params.arch.to_string().to_lowercase());
-    cmd.arg("--target").arg(format!("lib/{}.json", build_params.target()));
-    cmd.arg("--").arg("--emit").arg("asm");
-    build_params.add_build_arg(&mut cmd);
-    if build_params.verbose {
-        println!("Executing {cmd:?}");
-    }
-    let status = annotated_status(&mut cmd)?;
-    if !status.success() {
-        return Err("build kernel failed".into());
-    }
-    Ok(())
+struct BuildStep {
+    arch: Arch,
+    config: Configuration,
+    profile: Profile,
+    verbose: bool,
 }
 
-fn dist(build_params: &BuildParams) -> Result<()> {
-    build(build_params)?;
+impl BuildStep {
+    fn new(matches: &clap::ArgMatches) -> Self {
+        let arch = *matches.get_one::<Arch>("arch").unwrap();
+        let config = load_config(arch, matches);
+        let profile = Profile::from(matches);
+        let verbose = verbose(matches);
 
-    match build_params.arch {
-        Arch::Aarch64 => {
-            // Qemu needs a flat binary in order to handle device tree files correctly
-            let mut cmd = Command::new(objcopy());
-            cmd.arg("-O");
-            cmd.arg("binary");
-            cmd.arg(format!("target/{}/{}/aarch64", build_params.target(), build_params.dir()));
-            cmd.arg(format!(
-                "target/{}/{}/aarch64-qemu",
-                build_params.target(),
-                build_params.dir()
-            ));
-            cmd.current_dir(workspace());
-            if build_params.verbose {
-                println!("Executing {cmd:?}");
-            }
-            let status = annotated_status(&mut cmd)?;
-            if !status.success() {
-                return Err("objcopy failed".into());
-            }
-
-            // Compress the binary.  We do this because they're much faster when used
-            // for netbooting and qemu also accepts them.
-            let mut cmd = Command::new("gzip");
-            cmd.arg("-k");
-            cmd.arg("-f");
-            cmd.arg(format!(
-                "target/{}/{}/aarch64-qemu",
-                build_params.target(),
-                build_params.dir()
-            ));
-            cmd.current_dir(workspace());
-            if build_params.verbose {
-                println!("Executing {cmd:?}");
-            }
-            let status = annotated_status(&mut cmd)?;
-            if !status.success() {
-                return Err("gzip failed".into());
-            }
-        }
-        Arch::X86_64 => {
-            let mut cmd = Command::new(objcopy());
-            cmd.arg("--input-target=elf64-x86-64");
-            cmd.arg("--output-target=elf32-i386");
-            cmd.arg(format!("target/{}/{}/x86_64", build_params.target(), build_params.dir()));
-            cmd.arg(format!("target/{}/{}/r9.elf32", build_params.target(), build_params.dir()));
-            cmd.current_dir(workspace());
-            if build_params.verbose {
-                println!("Executing {cmd:?}");
-            }
-            let status = annotated_status(&mut cmd)?;
-            if !status.success() {
-                return Err("objcopy failed".into());
-            }
-        }
-        Arch::Riscv64 => {
-            // Qemu needs a flat binary in order to handle device tree files correctly
-            let mut cmd = Command::new(objcopy());
-            cmd.arg("-O");
-            cmd.arg("binary");
-            cmd.arg(format!("target/{}/{}/riscv64", build_params.target(), build_params.dir()));
-            cmd.arg(format!(
-                "target/{}/{}/riscv64-qemu",
-                build_params.target(),
-                build_params.dir()
-            ));
-            cmd.current_dir(workspace());
-            if build_params.verbose {
-                println!("Executing {cmd:?}");
-            }
-            let status = annotated_status(&mut cmd)?;
-            if !status.success() {
-                return Err("objcopy failed".into());
-            }
-        }
-    };
-
-    Ok(())
-}
-
-/// Run tests for the current host toolchain.
-fn test(build_params: &BuildParams) -> Result<()> {
-    let mut all_cmd_args = Vec::new();
-
-    all_cmd_args.push(vec![
-        "test".to_string(),
-        "--package".to_string(),
-        "port".to_string(),
-        "--lib".to_string(),
-    ]);
-
-    let rustup_state = RustupState::new();
-
-    let arch = std::env::consts::ARCH;
-    if let Some(target) = rustup_state.std_supported_target(arch) {
-        all_cmd_args.push(vec![
-            "test".to_string(),
-            "--package".to_string(),
-            arch.to_string(),
-            "--bins".to_string(),
-            "--target".to_string(),
-            target.to_string(),
-        ]);
+        Self { arch, config, profile, verbose }
     }
 
-    for cmd_args in all_cmd_args {
-        let mut cmd = Command::new(cargo());
+    fn run(self) -> Result<()> {
+        let mut cmd = generate_args(
+            "build",
+            &self.config,
+            &self.arch.target(),
+            &self.profile,
+            workspace().to_str().unwrap(),
+        );
         cmd.current_dir(workspace());
-
-        cmd.args(cmd_args);
-        if build_params.json_output {
-            cmd.arg("--message-format=json").arg("--quiet");
+        cmd.arg("--workspace");
+        cmd.arg("--exclude").arg("xtask");
+        exclude_other_arches(self.arch, &mut cmd);
+        if self.profile == Profile::Release {
+            cmd.arg("--release");
         }
-
-        if build_params.verbose {
+        if self.verbose {
             println!("Executing {cmd:?}");
         }
         let status = annotated_status(&mut cmd)?;
         if !status.success() {
-            return Err("check failed".into());
+            return Err("build kernel failed".into());
         }
+        Ok(())
     }
-    Ok(())
 }
 
-fn clippy(build_params: &BuildParams) -> Result<()> {
-    let mut cmd = generate_args(
-        "clippy",
-        &build_params.config,
-        &build_params.target(),
-        &build_params.profile,
-        workspace().to_str().unwrap(),
-    );
-    cmd.current_dir(workspace());
-    cmd.arg("--workspace");
-    exclude_other_arches(build_params.arch, &mut cmd);
-    build_params.add_build_arg(&mut cmd);
-    if build_params.verbose {
-        println!("Executing {cmd:?}");
+struct DistStep {
+    arch: Arch,
+    profile: Profile,
+    verbose: bool,
+}
+
+impl DistStep {
+    fn new(matches: &clap::ArgMatches) -> Self {
+        let arch = Arch::from(matches);
+        let profile = Profile::from(matches);
+        let verbose = verbose(matches);
+        Self { arch, profile, verbose }
     }
-    let status = annotated_status(&mut cmd)?;
-    if !status.success() {
-        return Err("clippy failed".into());
+
+    fn run(self) -> Result<()> {
+        match self.arch {
+            Arch::Aarch64 => {
+                // Qemu needs a flat binary in order to handle device tree files correctly
+                let mut cmd = Command::new(objcopy());
+                cmd.arg("-O");
+                cmd.arg("binary");
+                cmd.arg(format!("target/{}/{}/aarch64", self.arch.target(), self.profile.dir()));
+                cmd.arg(format!(
+                    "target/{}/{}/aarch64-qemu",
+                    self.arch.target(),
+                    self.profile.dir()
+                ));
+                cmd.current_dir(workspace());
+                if self.verbose {
+                    println!("Executing {cmd:?}");
+                }
+                let status = annotated_status(&mut cmd)?;
+                if !status.success() {
+                    return Err("objcopy failed".into());
+                }
+
+                // Compress the binary.  We do this because they're much faster when used
+                // for netbooting and qemu also accepts them.
+                let mut cmd = Command::new("gzip");
+                cmd.arg("-k");
+                cmd.arg("-f");
+                cmd.arg(format!(
+                    "target/{}/{}/aarch64-qemu",
+                    self.arch.target(),
+                    self.profile.dir()
+                ));
+                cmd.current_dir(workspace());
+                if self.verbose {
+                    println!("Executing {cmd:?}");
+                }
+                let status = annotated_status(&mut cmd)?;
+                if !status.success() {
+                    return Err("gzip failed".into());
+                }
+            }
+            Arch::X86_64 => {
+                let mut cmd = Command::new(objcopy());
+                cmd.arg("--input-target=elf64-x86-64");
+                cmd.arg("--output-target=elf32-i386");
+                cmd.arg(format!("target/{}/{}/x86_64", self.arch.target(), self.profile.dir()));
+                cmd.arg(format!("target/{}/{}/r9.elf32", self.arch.target(), self.profile.dir()));
+                cmd.current_dir(workspace());
+                if self.verbose {
+                    println!("Executing {cmd:?}");
+                }
+                let status = annotated_status(&mut cmd)?;
+                if !status.success() {
+                    return Err("objcopy failed".into());
+                }
+            }
+            Arch::Riscv64 => {
+                // Qemu needs a flat binary in order to handle device tree files correctly
+                let mut cmd = Command::new(objcopy());
+                cmd.arg("-O");
+                cmd.arg("binary");
+                cmd.arg(format!("target/{}/{}/riscv64", self.arch.target(), self.profile.dir()));
+                cmd.arg(format!(
+                    "target/{}/{}/riscv64-qemu",
+                    self.arch.target(),
+                    self.profile.dir()
+                ));
+                cmd.current_dir(workspace());
+                if self.verbose {
+                    println!("Executing {cmd:?}");
+                }
+                let status = annotated_status(&mut cmd)?;
+                if !status.success() {
+                    return Err("objcopy failed".into());
+                }
+            }
+        };
+
+        Ok(())
     }
-    Ok(())
+}
+
+struct QemuStep {
+    arch: Arch,
+    profile: Profile,
+    wait_for_gdb: bool,
+    kvm: bool,
+    dump_dtb: String,
+    verbose: bool,
+}
+
+impl QemuStep {
+    fn new(matches: &clap::ArgMatches) -> Self {
+        let arch = Arch::from(matches);
+        let profile = Profile::from(matches);
+        let wait_for_gdb = matches.get_flag("gdb");
+        let kvm = matches.get_flag("kvm");
+        let dump_dtb: String = matches
+            .try_get_one::<String>("dump_dtb")
+            .ok()
+            .flatten()
+            .unwrap_or(&"".to_string())
+            .clone();
+        let verbose = verbose(matches);
+
+        Self { arch, profile, wait_for_gdb, kvm, dump_dtb, verbose }
+    }
+
+    fn run(self) -> Result<()> {
+        let target = self.arch.target();
+        let dir = self.profile.dir();
+        let qemu_system = self.arch.qemu_system();
+
+        if self.kvm && self.arch != Arch::X86_64 {
+            return Err("KVM only supported under x86-64".into());
+        }
+
+        match self.arch {
+            Arch::Aarch64 => {
+                let mut cmd = Command::new(qemu_system);
+
+                // TODO Choose UART at cmdline
+                // If using UART0 (PL011), this enables serial
+                cmd.arg("-nographic");
+
+                // If using UART1 (MiniUART), this enables serial
+                cmd.arg("-serial");
+                cmd.arg("null");
+                cmd.arg("-serial");
+                cmd.arg("mon:stdio");
+
+                cmd.arg("-M");
+                cmd.arg("raspi3b");
+                if self.wait_for_gdb {
+                    cmd.arg("-s").arg("-S");
+                }
+                cmd.arg("-dtb");
+                cmd.arg("aarch64/lib/bcm2710-rpi-3-b.dtb");
+                // Show exception level change events in stdout
+                cmd.arg("-d");
+                cmd.arg("int");
+                cmd.arg("-kernel");
+                cmd.arg(format!("target/{}/{}/aarch64-qemu.gz", target, dir));
+                cmd.current_dir(workspace());
+                if self.verbose {
+                    println!("Executing {cmd:?}");
+                }
+                let status = annotated_status(&mut cmd)?;
+                if !status.success() {
+                    return Err("qemu failed".into());
+                }
+            }
+            Arch::Riscv64 => {
+                let mut cmd = Command::new(qemu_system);
+                cmd.arg("-nographic");
+                //cmd.arg("-curses");
+                // cmd.arg("-bios").arg("none");
+                let dump_dtb = &self.dump_dtb;
+                if dump_dtb != "" {
+                    cmd.arg("-machine").arg(format!("virt,dumpdtb={dump_dtb}"));
+                } else {
+                    cmd.arg("-machine").arg("virt");
+                }
+                cmd.arg("-cpu").arg("rv64");
+                // FIXME: This is not needed as of now, and will only work once the
+                // FIXME: // disk.bin is also taken care of. Doesn't exist by default.
+                if false {
+                    cmd.arg("-drive").arg("file=disk.bin,format=raw,id=hd0");
+                    cmd.arg("-device").arg("virtio-blk-device,drive=hd0");
+                }
+                cmd.arg("-netdev").arg("type=user,id=net0");
+                cmd.arg("-device").arg("virtio-net-device,netdev=net0");
+                cmd.arg("-smp").arg("4");
+                cmd.arg("-m").arg("1024M");
+                cmd.arg("-serial").arg("mon:stdio");
+                if self.wait_for_gdb {
+                    cmd.arg("-s").arg("-S");
+                }
+                cmd.arg("-d").arg("guest_errors,unimp");
+                cmd.arg("-kernel");
+                cmd.arg(format!("target/{}/{}/riscv64", target, dir));
+                cmd.current_dir(workspace());
+                if self.verbose {
+                    println!("Executing {cmd:?}");
+                }
+                let status = annotated_status(&mut cmd)?;
+                if !status.success() {
+                    return Err("qemu failed".into());
+                }
+            }
+            Arch::X86_64 => {
+                let mut cmd = Command::new(qemu_system);
+                cmd.arg("-nographic");
+                //cmd.arg("-curses");
+                if self.kvm {
+                    cmd.arg("-accel").arg("kvm");
+                    cmd.arg("-cpu").arg("host,pdpe1gb,xsaveopt,fsgsbase,apic,msr");
+                } else {
+                    cmd.arg("-M").arg("q35");
+                    cmd.arg("-cpu").arg("qemu64,pdpe1gb,xsaveopt,fsgsbase,apic,msr");
+                }
+                cmd.arg("-smp");
+                cmd.arg("8");
+                cmd.arg("-s");
+                cmd.arg("-m");
+                cmd.arg("8192");
+                if self.wait_for_gdb {
+                    cmd.arg("-s").arg("-S");
+                }
+                //cmd.arg("-device");
+                //cmd.arg("ahci,id=ahci0");
+                //cmd.arg("-drive");
+                //cmd.arg("id=sdahci0,file=sdahci0.img,if=none");
+                //cmd.arg("-device");
+                //cmd.arg("ide-hd,drive=sdahci0,bus=ahci0.0");
+                cmd.arg("-kernel");
+                cmd.arg(format!("target/{}/{}/r9.elf32", target, dir));
+                cmd.current_dir(workspace());
+                if self.verbose {
+                    println!("Executing {cmd:?}");
+                }
+                let status = annotated_status(&mut cmd)?;
+                if !status.success() {
+                    return Err("qemu failed".into());
+                }
+            }
+        };
+
+        Ok(())
+    }
+}
+
+struct ExpandStep {
+    arch: Arch,
+    profile: Profile,
+    verbose: bool,
+}
+
+impl ExpandStep {
+    fn new(matches: &clap::ArgMatches) -> Self {
+        let arch = Arch::from(matches);
+        let profile = Profile::from(matches);
+        let verbose = verbose(matches);
+
+        Self { arch, profile, verbose }
+    }
+
+    fn run(self) -> Result<()> {
+        let mut cmd = Command::new(cargo());
+        cmd.current_dir(workspace());
+        cmd.arg("rustc");
+        cmd.arg("-Z").arg("build-std=core,alloc");
+        cmd.arg("-p").arg(self.arch.to_string().to_lowercase());
+        cmd.arg("--target").arg(format!("lib/{}.json", self.arch.target()));
+        cmd.arg("--");
+        cmd.arg("-Z").arg("unpretty=expanded");
+        if self.profile == Profile::Release {
+            cmd.arg("--release");
+        }
+        if self.verbose {
+            println!("Executing {cmd:?}");
+        }
+        let status = annotated_status(&mut cmd)?;
+        if !status.success() {
+            return Err("build kernel failed".into());
+        }
+        Ok(())
+    }
+}
+
+struct KasmStep {
+    arch: Arch,
+    profile: Profile,
+    verbose: bool,
+}
+
+impl KasmStep {
+    fn new(matches: &clap::ArgMatches) -> Self {
+        let arch = Arch::from(matches);
+        let profile = Profile::from(matches);
+        let verbose = verbose(matches);
+
+        Self { arch, profile, verbose }
+    }
+
+    fn run(self) -> Result<()> {
+        let mut cmd = Command::new(cargo());
+        cmd.current_dir(workspace());
+        cmd.arg("rustc");
+        cmd.arg("-Z").arg("build-std=core,alloc");
+        cmd.arg("-p").arg(self.arch.to_string().to_lowercase());
+        cmd.arg("--target").arg(format!("lib/{}.json", self.arch.target()));
+        cmd.arg("--").arg("--emit").arg("asm");
+        if self.profile == Profile::Release {
+            cmd.arg("--release");
+        }
+        if self.verbose {
+            println!("Executing {cmd:?}");
+        }
+        let status = annotated_status(&mut cmd)?;
+        if !status.success() {
+            return Err("build kernel failed".into());
+        }
+        Ok(())
+    }
+}
+
+/// Run tests for the current host toolchain.
+struct TestStep {
+    json_output: bool,
+    verbose: bool,
+}
+
+impl TestStep {
+    fn new(matches: &clap::ArgMatches) -> Self {
+        let json_output = matches.get_flag("json");
+        let verbose = verbose(matches);
+
+        Self { json_output, verbose }
+    }
+
+    fn run(self) -> Result<()> {
+        let mut all_cmd_args = Vec::new();
+
+        all_cmd_args.push(vec![
+            "test".to_string(),
+            "--package".to_string(),
+            "port".to_string(),
+            "--lib".to_string(),
+        ]);
+
+        let rustup_state = RustupState::new();
+
+        let arch = std::env::consts::ARCH;
+        if let Some(target) = rustup_state.std_supported_target(arch) {
+            all_cmd_args.push(vec![
+                "test".to_string(),
+                "--package".to_string(),
+                arch.to_string(),
+                "--bins".to_string(),
+                "--target".to_string(),
+                target.to_string(),
+            ]);
+        }
+
+        for cmd_args in all_cmd_args {
+            let mut cmd = Command::new(cargo());
+            cmd.current_dir(workspace());
+
+            cmd.args(cmd_args);
+            if self.json_output {
+                cmd.arg("--message-format=json").arg("--quiet");
+            }
+
+            if self.verbose {
+                println!("Executing {cmd:?}");
+            }
+            let status = annotated_status(&mut cmd)?;
+            if !status.success() {
+                return Err("check failed".into());
+            }
+        }
+        Ok(())
+    }
+}
+
+struct ClippyStep {
+    arch: Arch,
+    config: Configuration,
+    profile: Profile,
+    verbose: bool,
+}
+
+impl ClippyStep {
+    fn new(matches: &clap::ArgMatches) -> Self {
+        let arch = Arch::from(matches);
+        let config = load_config(arch, matches);
+        let profile = Profile::from(matches);
+        let verbose = verbose(matches);
+
+        Self { arch, config, profile, verbose }
+    }
+
+    fn run(self) -> Result<()> {
+        let mut cmd = generate_args(
+            "clippy",
+            &self.config,
+            &self.arch.target(),
+            &self.profile,
+            workspace().to_str().unwrap(),
+        );
+        cmd.current_dir(workspace());
+        cmd.arg("--workspace");
+        exclude_other_arches(self.arch, &mut cmd);
+        if self.profile == Profile::Release {
+            cmd.arg("--release");
+        }
+        if self.verbose {
+            println!("Executing {cmd:?}");
+        }
+        let status = annotated_status(&mut cmd)?;
+        if !status.success() {
+            return Err("clippy failed".into());
+        }
+        Ok(())
+    }
 }
 
 /// Run check for all packages for all relevant toolchains.
 /// This assumes that the <arch>-unknown-linux-gnu toolchain has been installed
 /// for any arch we care about.
-fn check(build_params: &BuildParams) -> Result<()> {
-    // To run check for bins and lib we use the default toolchain, which has
-    // been set to the OS-independent arch toolchain in each Cargo.toml file.
-    // The same applies to tests and benches for non-arch-specific lib packages.
-    let bins_lib_package_cmd_args = vec![
-        vec![
-            "check".to_string(),
-            "--package".to_string(),
-            "aarch64".to_string(),
-            "--bins".to_string(),
-        ],
-        vec![
-            "check".to_string(),
-            "--package".to_string(),
-            "riscv64".to_string(),
-            "--bins".to_string(),
-        ],
-        vec![
-            "check".to_string(),
-            "--package".to_string(),
-            "x86_64".to_string(),
-            "--bins".to_string(),
-        ],
-        vec![
-            "check".to_string(),
-            "--package".to_string(),
-            "port".to_string(),
-            "--lib".to_string(),
-            "--tests".to_string(),
-            "--benches".to_string(),
-        ],
-    ];
+struct CheckStep {
+    json_output: bool,
+    verbose: bool,
+}
 
-    let rustup_state = RustupState::new();
+impl CheckStep {
+    fn new(matches: &clap::ArgMatches) -> Self {
+        let json_output = matches.get_flag("json");
+        let verbose = verbose(matches);
 
-    // However, running check for tests and benches in arch packages requires
-    // that we use a toolchain with `std`, so we need an OS-specific toolchain.
-    // If the arch matches that of the current toolchain, then that will be used
-    // for check.  Otherwise we'll always default to <arch>-unknown-linux-gnu.
-    let mut benches_tests_package_cmd_args = Vec::new();
-
-    for arch in ["aarch64", "riscv64", "x86_64"] {
-        let Some(target) = rustup_state.std_supported_target(arch) else {
-            continue;
-        };
-
-        benches_tests_package_cmd_args.push(vec![
-            "check".to_string(),
-            "--package".to_string(),
-            arch.to_string(),
-            "--tests".to_string(),
-            "--benches".to_string(),
-            "--target".to_string(),
-            target.to_string(),
-        ]);
+        Self { json_output, verbose }
     }
 
-    for cmd_args in [bins_lib_package_cmd_args, benches_tests_package_cmd_args].concat() {
-        let mut cmd = Command::new(cargo());
-        cmd.args(cmd_args);
-        if build_params.json_output {
-            cmd.arg("--message-format=json").arg("--quiet");
-        }
-        cmd.current_dir(workspace());
+    fn run(self) -> Result<()> {
+        // To run check for bins and lib we use the default toolchain, which has
+        // been set to the OS-independent arch toolchain in each Cargo.toml file.
+        // The same applies to tests and benches for non-arch-specific lib packages.
+        let bins_lib_package_cmd_args = vec![
+            vec![
+                "check".to_string(),
+                "--package".to_string(),
+                "aarch64".to_string(),
+                "--bins".to_string(),
+            ],
+            vec![
+                "check".to_string(),
+                "--package".to_string(),
+                "riscv64".to_string(),
+                "--bins".to_string(),
+            ],
+            vec![
+                "check".to_string(),
+                "--package".to_string(),
+                "x86_64".to_string(),
+                "--bins".to_string(),
+            ],
+            vec![
+                "check".to_string(),
+                "--package".to_string(),
+                "port".to_string(),
+                "--lib".to_string(),
+                "--tests".to_string(),
+                "--benches".to_string(),
+            ],
+        ];
 
-        if build_params.verbose {
-            println!("Executing {cmd:?}");
+        let rustup_state = RustupState::new();
+
+        // However, running check for tests and benches in arch packages requires
+        // that we use a toolchain with `std`, so we need an OS-specific toolchain.
+        // If the arch matches that of the current toolchain, then that will be used
+        // for check.  Otherwise we'll always default to <arch>-unknown-linux-gnu.
+        let mut benches_tests_package_cmd_args = Vec::new();
+
+        for arch in ["aarch64", "riscv64", "x86_64"] {
+            let Some(target) = rustup_state.std_supported_target(arch) else {
+                continue;
+            };
+
+            benches_tests_package_cmd_args.push(vec![
+                "check".to_string(),
+                "--package".to_string(),
+                arch.to_string(),
+                "--tests".to_string(),
+                "--benches".to_string(),
+                "--target".to_string(),
+                target.to_string(),
+            ]);
         }
+
+        for cmd_args in [bins_lib_package_cmd_args, benches_tests_package_cmd_args].concat() {
+            let mut cmd = Command::new(cargo());
+            cmd.args(cmd_args);
+            if self.json_output {
+                cmd.arg("--message-format=json").arg("--quiet");
+            }
+            cmd.current_dir(workspace());
+
+            if self.verbose {
+                println!("Executing {cmd:?}");
+            }
+            let status = annotated_status(&mut cmd)?;
+            if !status.success() {
+                return Err("check failed".into());
+            }
+        }
+        Ok(())
+    }
+}
+
+struct CleanStep {}
+
+impl CleanStep {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn run(self) -> Result<()> {
+        let mut cmd = Command::new(cargo());
+        cmd.current_dir(workspace());
+        cmd.arg("clean");
         let status = annotated_status(&mut cmd)?;
         if !status.success() {
-            return Err("check failed".into());
+            return Err("clean failed".into());
         }
+        Ok(())
     }
-    Ok(())
-}
-
-fn run(build_params: &BuildParams) -> Result<()> {
-    dist(build_params)?;
-
-    match build_params.arch {
-        Arch::Aarch64 => {
-            let mut cmd = Command::new(build_params.qemu_system());
-
-            // TODO Choose UART at cmdline
-            // If using UART0 (PL011), this enables serial
-            cmd.arg("-nographic");
-
-            // If using UART1 (MiniUART), this enables serial
-            cmd.arg("-serial");
-            cmd.arg("null");
-            cmd.arg("-serial");
-            cmd.arg("mon:stdio");
-
-            cmd.arg("-M");
-            cmd.arg("raspi3b");
-            if build_params.wait_for_gdb {
-                cmd.arg("-s").arg("-S");
-            }
-            cmd.arg("-dtb");
-            cmd.arg("aarch64/lib/bcm2710-rpi-3-b.dtb");
-            // Show exception level change events in stdout
-            cmd.arg("-d");
-            cmd.arg("int");
-            cmd.arg("-kernel");
-            cmd.arg(format!(
-                "target/{}/{}/aarch64-qemu.gz",
-                build_params.target(),
-                build_params.dir()
-            ));
-            cmd.current_dir(workspace());
-            if build_params.verbose {
-                println!("Executing {cmd:?}");
-            }
-            let status = annotated_status(&mut cmd)?;
-            if !status.success() {
-                return Err("qemu failed".into());
-            }
-        }
-        Arch::Riscv64 => {
-            let mut cmd = Command::new(build_params.qemu_system());
-            cmd.arg("-nographic");
-            //cmd.arg("-curses");
-            // cmd.arg("-bios").arg("none");
-            let dump_dtb = &build_params.dump_dtb;
-            if dump_dtb != "" {
-                cmd.arg("-machine").arg(format!("virt,dumpdtb={dump_dtb}"));
-            } else {
-                cmd.arg("-machine").arg("virt");
-            }
-            cmd.arg("-cpu").arg("rv64");
-            // FIXME: This is not needed as of now, and will only work once the
-            // FIXME: // disk.bin is also taken care of. Doesn't exist by default.
-            if false {
-                cmd.arg("-drive").arg("file=disk.bin,format=raw,id=hd0");
-                cmd.arg("-device").arg("virtio-blk-device,drive=hd0");
-            }
-            cmd.arg("-netdev").arg("type=user,id=net0");
-            cmd.arg("-device").arg("virtio-net-device,netdev=net0");
-            cmd.arg("-smp").arg("4");
-            cmd.arg("-m").arg("1024M");
-            cmd.arg("-serial").arg("mon:stdio");
-            if build_params.wait_for_gdb {
-                cmd.arg("-s").arg("-S");
-            }
-            cmd.arg("-d").arg("guest_errors,unimp");
-            cmd.arg("-kernel");
-            cmd.arg(format!("target/{}/{}/riscv64", build_params.target(), build_params.dir()));
-            cmd.current_dir(workspace());
-            if build_params.verbose {
-                println!("Executing {cmd:?}");
-            }
-            let status = annotated_status(&mut cmd)?;
-            if !status.success() {
-                return Err("qemu failed".into());
-            }
-        }
-        Arch::X86_64 => {
-            let mut cmd = Command::new(build_params.qemu_system());
-            cmd.arg("-nographic");
-            //cmd.arg("-curses");
-            cmd.arg("-M");
-            cmd.arg("q35");
-            cmd.arg("-cpu");
-            cmd.arg("qemu64,pdpe1gb,xsaveopt,fsgsbase,apic,msr");
-            cmd.arg("-smp");
-            cmd.arg("8");
-            cmd.arg("-s");
-            cmd.arg("-m");
-            cmd.arg("8192");
-            if build_params.wait_for_gdb {
-                cmd.arg("-s").arg("-S");
-            }
-            //cmd.arg("-device");
-            //cmd.arg("ahci,id=ahci0");
-            //cmd.arg("-drive");
-            //cmd.arg("id=sdahci0,file=sdahci0.img,if=none");
-            //cmd.arg("-device");
-            //cmd.arg("ide-hd,drive=sdahci0,bus=ahci0.0");
-            cmd.arg("-kernel");
-            cmd.arg(format!("target/{}/{}/r9.elf32", build_params.target(), build_params.dir()));
-            cmd.current_dir(workspace());
-            if build_params.verbose {
-                println!("Executing {cmd:?}");
-            }
-            let status = annotated_status(&mut cmd)?;
-            if !status.success() {
-                return Err("qemu failed".into());
-            }
-        }
-    };
-
-    Ok(())
-}
-
-fn accelrun(build_params: &BuildParams) -> Result<()> {
-    dist(build_params)?;
-    let mut cmd = Command::new(build_params.qemu_system());
-    cmd.arg("-nographic");
-    cmd.arg("-accel");
-    cmd.arg("kvm");
-    cmd.arg("-cpu");
-    cmd.arg("host,pdpe1gb,xsaveopt,fsgsbase,apic,msr");
-    cmd.arg("-smp");
-    cmd.arg("8");
-    cmd.arg("-m");
-    cmd.arg("8192");
-    if build_params.wait_for_gdb {
-        cmd.arg("-s").arg("-S");
-    }
-    cmd.arg("-kernel");
-    cmd.arg(format!("target/{}/{}/r9.elf32", build_params.target(), build_params.dir()));
-    cmd.current_dir(workspace());
-    if build_params.verbose {
-        println!("Executing {cmd:?}");
-    }
-    let status = annotated_status(&mut cmd)?;
-    if !status.success() {
-        return Err("qemu failed".into());
-    }
-    Ok(())
-}
-
-fn clean() -> Result<()> {
-    let mut cmd = Command::new(cargo());
-    cmd.current_dir(workspace());
-    cmd.arg("clean");
-    let status = annotated_status(&mut cmd)?;
-    if !status.success() {
-        return Err("clean failed".into());
-    }
-    Ok(())
 }
 
 fn workspace() -> PathBuf {
     Path::new(&env!("CARGO_MANIFEST_DIR")).ancestors().nth(1).unwrap().to_path_buf()
 }
 
-// Exclude architectures other than the one being built
+/// Exclude architectures other than the one being built
 fn exclude_other_arches(arch: Arch, cmd: &mut Command) {
     match arch {
         Arch::Aarch64 => {
@@ -769,7 +875,7 @@ fn exclude_other_arches(arch: Arch, cmd: &mut Command) {
     }
 }
 
-// Annotates the error result with the calling binary's name.
+/// Annotates the error result with the calling binary's name.
 fn annotated_status(cmd: &mut Command) -> Result<process::ExitStatus> {
     Ok(cmd.status().map_err(|e| format!("{}: {}", cmd.get_program().to_string_lossy(), e))?)
 }


### PR DESCRIPTION
Separate build into most distinct stages, each with their own argument parsing.  This suits clap better, and makes each step independent.

Combine qemu and qemukvm.

Fix parsing of profile flag arg (probably amongst others) - was always building in release mode.

Tidy memory map output in aarch64 by sorting.