### PR TITLE
Fix aarch64 4KiB page tables, tidy recursive page tables

### DIFF
--- a/aarch64/lib/kernel.ld
+++ b/aarch64/lib/kernel.ld
@@ -51,13 +51,6 @@ SECTIONS {
 	}
 	ebss = .;
 
-	/* Reserve section for kernel heap.  Align to 2MiB to allow us to map as
-	   a 2MiB page. */
-	. = ALIGN(2 * 1024 * 1024);
-	heap = .;
-	. += 64 * 1024 * 1024;
-	eheap = .;
-
 	/* Reserve section for early pagetables.  Align to 2MiB to allow us to map
 	   as a 2MiB page.Note that this won't be needed once we transition to
 	   recursive pagetables.

--- a/aarch64/src/devcons.rs
+++ b/aarch64/src/devcons.rs
@@ -1,11 +1,10 @@
 // Racy to start.
 
-use crate::registers::rpi_mmio;
+use crate::param::KZERO;
 use crate::uartmini::MiniUart;
 use core::mem::MaybeUninit;
 use port::devcons::Console;
 use port::fdt::DeviceTree;
-use port::mem::VirtRange;
 
 // The aarch64 devcons implementation is focussed on Raspberry Pi 3, 4 for now.
 
@@ -32,16 +31,10 @@ use port::mem::VirtRange;
 //     https://wiki.osdev.org/Detecting_Raspberry_Pi_Board
 // - Break out mailbox, gpio code
 
-pub fn init(_dt: &DeviceTree) {
+pub fn init(dt: &DeviceTree) {
     Console::new(|| {
-        let mmio = rpi_mmio().expect("mmio base detect failed").to_virt();
-        let gpio_range = VirtRange::with_len(mmio + 0x20_0000, 0xb4);
-        let aux_range = VirtRange::with_len(mmio + 0x21_5000, 0x8);
-        let miniuart_range = VirtRange::with_len(mmio + 0x21_5040, 0x40);
-
-        let uart = MiniUart { gpio_range, aux_range, miniuart_range };
-        //let uart = MiniUart::new(dt);
-        // uart.init();
+        let uart = MiniUart::new(dt, KZERO);
+        uart.init();
 
         static mut UART: MaybeUninit<MiniUart> = MaybeUninit::uninit();
         unsafe {

--- a/aarch64/src/kmem.rs
+++ b/aarch64/src/kmem.rs
@@ -14,8 +14,6 @@ extern "C" {
     static ebss: [u64; 0];
     static early_pagetables: [u64; 0];
     static eearly_pagetables: [u64; 0];
-    static heap: [u64; 0];
-    static eheap: [u64; 0];
 }
 
 pub fn text_addr() -> usize {
@@ -32,14 +30,6 @@ pub fn erodata_addr() -> usize {
 
 pub fn ebss_addr() -> usize {
     unsafe { ebss.as_ptr().addr() }
-}
-
-pub fn heap_addr() -> usize {
-    unsafe { heap.as_ptr().addr() }
-}
-
-pub fn eheap_addr() -> usize {
-    unsafe { eheap.as_ptr().addr() }
 }
 
 pub fn early_pagetables_addr() -> usize {

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -635,7 +635,7 @@ dnr:	wfe
 .balign 4096
 kernelpt4:
 	.space	(256*8)
-	.quad	(kernelpt3 - KZERO) + (PT_PAGE)		// [256] (for kernel + mmio)
+	.quad	(kernelpt3 - KZERO) + (PT_AF|PT_PAGE)	// [256] (for kernel + mmio)
 	.space	(254*8)
 	.quad	(kernelpt4 - KZERO) + (PT_AF|PT_PAGE)	// [511] (recursive entry)
 
@@ -643,31 +643,27 @@ kernelpt4:
 kernelpt3:
  	.quad	(0*2*GiB) + (PT_BLOCK|PT_AF|PT_AP_KERNEL_RW|PT_ISH|PT_UXN|PT_MAIR_NORMAL)	// [0] (for kernel)
 	.space	(2*8)
-	.quad	(kernelpt2 - KZERO) + (PT_PAGE)		// [3] (for mmio)
-	.space	(507*8)
-	.quad	(kernelpt3 - KZERO) + (PT_AF|PT_PAGE)	// [511] (recursive entry)
+	.quad	(kernelpt2 - KZERO) + (PT_AF|PT_PAGE)	// [3] (for mmio)
+	.space	(508*8)
 
 .balign 4096
 kernelpt2:
 	.space	(496*8)
  	.quad	(MMIO_BASE_RPI4) + (PT_BLOCK|PT_AF|PT_AP_KERNEL_RW|PT_ISH|PT_UXN|PT_PXN|PT_MAIR_DEVICE)		// [496] (for mmio)
  	.quad	(MMIO_BASE_RPI4 + GPIO) + (PT_BLOCK|PT_AF|PT_AP_KERNEL_RW|PT_ISH|PT_UXN|PT_PXN|PT_MAIR_DEVICE)	// [497] (for mmio)
-	.space	(13*8)
-	.quad	(kernelpt2 - KZERO) + (PT_AF|PT_PAGE)	// [511] (recursive entry)
+	.space	(14*8)
 
 // Early page tables for identity mapping the kernel physical addresses.
 // Once we've jumped to the higher half, this will no longer be used.
 .balign 4096
 physicalpt4:
-	.quad	(physicalpt3 - KZERO) + (PT_PAGE)	// [0] (for kernel)
-	.space	(510*8)
-	.quad	(physicalpt4 - KZERO) + (PT_AF|PT_PAGE)	// [511] (recursive entry)
+	.quad	(physicalpt3 - KZERO) + (PT_AF|PT_PAGE)	// [0] (for kernel)
+	.space	(511*8)
 
 .balign 4096
 physicalpt3:
  	.quad	(0*2*GiB) + (PT_BLOCK|PT_AF|PT_AP_KERNEL_RW|PT_ISH|PT_UXN|PT_MAIR_NORMAL)	// [0] (for kernel)
-	.space	(510*8)
-	.quad	(physicalpt3 - KZERO) + (PT_AF|PT_PAGE)	// [511] (recursive entry)
+	.space	(511*8)
 
 .bss
 .balign	4096

--- a/aarch64/src/registers.rs
+++ b/aarch64/src/registers.rs
@@ -1,6 +1,6 @@
 #![allow(non_upper_case_globals)]
 
-use crate::kmem::PhysAddr;
+use crate::{kmem::PhysRange, vm::PAGE_SIZE_2M};
 use bitstruct::bitstruct;
 use core::fmt;
 use num_enum::TryFromPrimitive;
@@ -90,18 +90,19 @@ pub enum PartNum {
 }
 
 impl PartNum {
-    /// Return the physical MMIO base address for the Raspberry Pi MMIO
-    pub fn mmio(&self) -> Option<PhysAddr> {
+    /// Return the physical MMIO base range for the Raspberry Pi MMIO
+    pub fn mmio(&self) -> Option<PhysRange> {
+        let len = 2 * PAGE_SIZE_2M;
         match self {
-            Self::RaspberryPi1 => Some(PhysAddr::new(0x20000000)),
-            Self::RaspberryPi2 | Self::RaspberryPi3 => Some(PhysAddr::new(0x3f000000)),
-            Self::RaspberryPi4 => Some(PhysAddr::new(0xfe000000)),
+            Self::RaspberryPi1 => Some(PhysRange::with_len(0x20000000, len)),
+            Self::RaspberryPi2 | Self::RaspberryPi3 => Some(PhysRange::with_len(0x3f000000, len)),
+            Self::RaspberryPi4 => Some(PhysRange::with_len(0xfe000000, len)),
             Self::Unknown => None,
         }
     }
 }
 
-pub fn rpi_mmio() -> Option<PhysAddr> {
+pub fn rpi_mmio() -> Option<PhysRange> {
     MidrEl1::read().partnum_enum().ok().and_then(|p| p.mmio())
 }
 

--- a/aarch64/src/runtime.rs
+++ b/aarch64/src/runtime.rs
@@ -16,7 +16,7 @@ use port::mem::VirtRange;
 //  - Add support for raspi4
 #[panic_handler]
 pub fn panic(info: &PanicInfo) -> ! {
-    let mmio = rpi_mmio().expect("mmio base detect failed").to_virt();
+    let mmio = rpi_mmio().expect("mmio base detect failed").start().to_virt();
 
     let gpio_range = VirtRange::with_len(mmio + 0x200000, 0xb4);
     let aux_range = VirtRange::with_len(mmio + 0x215000, 0x8);

--- a/aarch64/src/uartmini.rs
+++ b/aarch64/src/uartmini.rs
@@ -20,7 +20,7 @@ pub struct MiniUart {
 
 #[allow(dead_code)]
 impl MiniUart {
-    pub fn new(dt: &DeviceTree, mmio_virt_offset: u64) -> MiniUart {
+    pub fn new(dt: &DeviceTree, mmio_virt_offset: usize) -> MiniUart {
         // TODO use aliases?
         let gpio_range = VirtRange::from(
             &dt.find_compatible("brcm,bcm2835-gpio")
@@ -28,7 +28,7 @@ impl MiniUart {
                 .and_then(|uart| dt.property_translated_reg_iter(uart).next())
                 .and_then(|reg| reg.regblock())
                 .unwrap()
-                .with_offset(mmio_virt_offset),
+                .with_offset(mmio_virt_offset as u64),
         );
 
         // Find a compatible aux
@@ -38,7 +38,7 @@ impl MiniUart {
                 .and_then(|uart| dt.property_translated_reg_iter(uart).next())
                 .and_then(|reg| reg.regblock())
                 .unwrap()
-                .with_offset(mmio_virt_offset),
+                .with_offset(mmio_virt_offset as u64),
         );
 
         // Find a compatible miniuart
@@ -48,7 +48,7 @@ impl MiniUart {
                 .and_then(|uart| dt.property_translated_reg_iter(uart).next())
                 .and_then(|reg| reg.regblock())
                 .unwrap()
-                .with_offset(mmio_virt_offset),
+                .with_offset(mmio_virt_offset as u64),
         );
 
         MiniUart { gpio_range, aux_range, miniuart_range }

--- a/port/src/fdt.rs
+++ b/port/src/fdt.rs
@@ -704,6 +704,7 @@ impl RegBlock {
     pub fn from_addr(addr: u64) -> RegBlock {
         RegBlock { addr, len: None }
     }
+
     pub fn with_offset(self, offset: u64) -> RegBlock {
         RegBlock { addr: self.addr + offset, len: self.len }
     }

--- a/port/src/mem.rs
+++ b/port/src/mem.rs
@@ -16,6 +16,14 @@ impl VirtRange {
             None
         }
     }
+
+    pub fn start(&self) -> usize {
+        self.0.start
+    }
+
+    pub fn end(&self) -> usize {
+        self.0.end
+    }
 }
 
 impl From<&RegBlock> for VirtRange {


### PR DESCRIPTION
- Fixes a bug in the handling of 4KiB page tables - we weren't marking the page flag correctly, so it only worked for  blocks (> 4KiB size).
- Removes recursive page entry from all but the top table (only need the top table to have a recursive entry to be able to access all tables).
- Use the device tree (via PhysRange) to initialise UART and related devices.