### PR TITLE
Add support for qemu machine raspi4b

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ check to ensure `qemu` or `qemu-kvm` is installed and the
 
 R9 can be run using qemu for the various supported architectures:
 
-|Arch|Commandline|
-|----|-----------|
-|aarch64|cargo xtask qemu --arch aarch64 --verbose|
-|x86-64|cargo xtask qemu --arch x86-64 --verbose|
-|x86-64 (with kvm)|cargo xtask qemu --arch x86-64 --kvm --verbose|
-|riscv|cargo xtask qemu --arch riscv64 --verbose|
+|Arch|Platform|Commandline|
+|----|--------|-----------|
+|aarch64|raspi3b|cargo xtask qemu --arch aarch64 --verbose|
+|aarch64|raspi4b|cargo xtask qemu --arch aarch64 --config raspi4b --verbose|
+|x86-64|q35|cargo xtask qemu --arch x86-64 --verbose|
+|x86-64 (with kvm)|q35|cargo xtask qemu --arch x86-64 --kvm --verbose|
+|riscv|virt|cargo xtask qemu --arch riscv64 --verbose|
 
 ## Running on Real Hardware™️
 

--- a/aarch64/lib/config_raspi4b.toml
+++ b/aarch64/lib/config_raspi4b.toml
@@ -10,5 +10,5 @@ script = 'aarch64/lib/kernel.ld'
 load-address = '0xffff800000100000 - 0x80000'
 
 [qemu]
-machine = "raspi3b"
-dtb = "aarch64/lib/bcm2710-rpi-3-b.dtb"
+machine = "raspi4b"
+dtb = "aarch64/lib/bcm2711-rpi-4-b.dtb"

--- a/aarch64/src/pagealloc.rs
+++ b/aarch64/src/pagealloc.rs
@@ -19,9 +19,9 @@ use port::{
 };
 
 /// Set up bitmap page allocator assuming everything is allocated.
-static PAGE_ALLOC: Lock<BitmapPageAlloc<16, PAGE_SIZE_4K>> = Lock::new(
+static PAGE_ALLOC: Lock<BitmapPageAlloc<32, PAGE_SIZE_4K>> = Lock::new(
     "page_alloc",
-    const { BitmapPageAlloc::<16, PAGE_SIZE_4K>::new_all_allocated(PAGE_SIZE_4K) },
+    const { BitmapPageAlloc::<32, PAGE_SIZE_4K>::new_all_allocated(PAGE_SIZE_4K) },
 );
 
 /// The bitmap allocator has all pages marked as allocated initially.  We'll

--- a/aarch64/src/uartmini.rs
+++ b/aarch64/src/uartmini.rs
@@ -20,10 +20,12 @@ pub struct MiniUart {
 #[allow(dead_code)]
 impl MiniUart {
     pub fn new(dt: &DeviceTree, mmio_virt_offset: usize) -> MiniUart {
-        // TODO use aliases?
+        // Bcm2835 and bcm2711 are essentially the same for our needs here.
+        // If fdt.rs supported aliases well, we could try to just look up 'gpio'.
         let gpio_range = VirtRange::from(
             &dt.find_compatible("brcm,bcm2835-gpio")
                 .next()
+                .or_else(|| dt.find_compatible("brcm,bcm2711-gpio").next())
                 .and_then(|uart| dt.property_translated_reg_iter(uart).next())
                 .and_then(|reg| reg.regblock())
                 .unwrap()

--- a/port/src/bitmapalloc.rs
+++ b/port/src/bitmapalloc.rs
@@ -35,6 +35,7 @@ impl<const SIZE_BYTES: usize> Bitmap<SIZE_BYTES> {
 
 #[derive(Debug, PartialEq)]
 pub enum BitmapPageAllocError {
+    NotEnoughBitmaps,
     OutOfBounds,
     MisalignedAddr,
     OutOfSpace,
@@ -215,7 +216,7 @@ impl<const NUM_BITMAPS: usize, const BITMAP_SIZE_BYTES: usize>
         check_end: bool,
     ) -> Result<(), BitmapPageAllocError> {
         if check_end && range.0.end > self.end {
-            return Err(BitmapPageAllocError::OutOfBounds);
+            return Err(BitmapPageAllocError::NotEnoughBitmaps);
         }
 
         for pa in range.step_by_rounded(self.alloc_page_size) {

--- a/port/src/mem.rs
+++ b/port/src/mem.rs
@@ -149,8 +149,7 @@ impl PhysRange {
 
 impl fmt::Display for PhysRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:#016x}..{:#016x}", self.0.start.addr(), self.0.end.addr())?;
-        Ok(())
+        write!(f, "{:#016x}..{:#016x}", self.0.start.addr(), self.0.end.addr())
     }
 }
 


### PR DESCRIPTION
Qemu 9.0 support raspi4b, so we're adding support for it here.  This meant a few changes to xtask and config to change the qemu args based on the config_xxx.toml.

To run in qemu as a raspi4b:
`cargo xtask qemu --arch aarch64 --config raspi4b --verbose`

(Default is raspi3b for now, since it's more widely available in older qemus)