### PR TITLE
riscv64: use SBI SRST extension instead of legacy SBI for system shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,23 @@ name = "riscv64"
 version = "0.1.0"
 dependencies = [
  "port",
+ "sbi-rt",
 ]
+
+[[package]]
+name = "sbi-rt"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbaa69be1eedc61c426e6d489b2260482e928b465360576900d52d496a58bd0"
+dependencies = [
+ "sbi-spec",
+]
+
+[[package]]
+name = "sbi-spec"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
 name = "serde"

--- a/riscv64/Cargo.toml
+++ b/riscv64/Cargo.toml
@@ -8,9 +8,9 @@ default-target = "riscv64gc-unknown-none-elf"
 
 [dependencies]
 port = { path = "../port" }
+sbi-rt = "0.0.3"
 
 [features]
-opensbi = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(platform, values("nezha"))', 'cfg(platform, values("virt"))'] }

--- a/riscv64/src/sbi.rs
+++ b/riscv64/src/sbi.rs
@@ -49,6 +49,8 @@ pub fn _consgetb() -> u8 {
 }
 
 pub fn shutdown() -> ! {
-    sbi_call_legacy(SBI_SHUTDOWN, 0, 0, 0);
-    panic!("shutdown failed!");
+    sbi_rt::system_reset(sbi_rt::Shutdown, sbi_rt::NoReason);
+    loop {
+        unsafe { core::arch::asm!("wfi") }
+    }
 }


### PR DESCRIPTION
Legacy SBI have been deprecated years ago (on Jun 9, 2021). Modern RISC-V SBI firmware would use SBI SRST extension to shutdown an S-mode environment; we use `sbi-rt` crate for this purpose.

Unused feature gate `opensbi` is removed, as RISC-V SBI support does not usually satisfy which implementation we'd use, unless e.g. fixing implementation-specific bugs.