### PR TITLE
Once VM set up, map device registers dynamically, remove bulk-mapped rpi MMIO region

### DIFF
--- a/aarch64/src/deviceutil.rs
+++ b/aarch64/src/deviceutil.rs
@@ -1,0 +1,28 @@
+use port::Result;
+use port::mem::{PhysRange, VirtRange};
+
+use crate::vm;
+
+/// Map a device register to device memory
+/// TODO Maybe make this a macro and wrap the error reporting?
+pub fn map_device_register(
+    id: &'static str,
+    physrange: PhysRange,
+    page_size: vm::PageSize,
+) -> Result<VirtRange> {
+    let page_physrange = physrange.round(page_size.size());
+
+    if let Ok(vr) = vm::kernel_pagetable().map_phys_range(
+        id,
+        &page_physrange,
+        vm::next_free_device_page4k(),
+        vm::Entry::rw_device(),
+        page_size,
+        vm::RootPageTableType::Kernel,
+    ) {
+        let offset = vr.start() - page_physrange.start().addr() as usize;
+        Ok(VirtRange::from_physrange(&physrange, offset))
+    } else {
+        Err("failed to map device register")
+    }
+}

--- a/aarch64/src/kmem.rs
+++ b/aarch64/src/kmem.rs
@@ -101,7 +101,8 @@ pub const fn physaddr_as_ptr_mut_offset_from_kzero<T>(pa: PhysAddr) -> *mut T {
 
 /// Given a virtual address, return the physical address.  Makes a massive assumption
 /// that the code is mapped offset to KZERO, so should be used with extreme care.
-pub fn from_virt_to_physaddr(va: usize) -> PhysAddr {
+/// TODO: Remove this altogether, otherwise it'll get used when it shouldn't.
+fn from_virt_to_physaddr(va: usize) -> PhysAddr {
     debug_assert!(va >= KZERO, "from_virt_to_physaddr: va {} must be >= KZERO ({})", va, KZERO);
     PhysAddr::new((va - KZERO) as u64)
 }

--- a/aarch64/src/mailbox.rs
+++ b/aarch64/src/mailbox.rs
@@ -1,6 +1,5 @@
 use crate::io::{read_reg, write_reg};
 use crate::param::KZERO;
-use core::ops::DerefMut;
 use port::fdt::DeviceTree;
 use port::mcslock::{Lock, LockNode};
 use port::mem::{PhysAddr, PhysRange, VirtRange};
@@ -120,12 +119,10 @@ where
     let node = LockNode::new();
     MAILBOX
         .lock(&node)
-        .deref_mut()
         .as_mut()
         .map(|mb| {
             mb.request(&mut msg);
-            let res = unsafe { msg.response };
-            res.tags.body
+            unsafe { msg.response.tags.body }
         })
         .expect("mailbox not initialised")
 }

--- a/aarch64/src/mailbox.rs
+++ b/aarch64/src/mailbox.rs
@@ -1,6 +1,5 @@
 use crate::io::{read_reg, write_reg};
 use crate::param::KZERO;
-use core::cell::RefCell;
 use core::ops::DerefMut;
 use port::fdt::DeviceTree;
 use port::mcslock::{Lock, LockNode};
@@ -13,7 +12,7 @@ const MBOX_WRITE: usize = 0x20;
 const MBOX_FULL: u32 = 0x8000_0000;
 const MBOX_EMPTY: u32 = 0x4000_0000;
 
-static MAILBOX: Lock<RefCell<Option<Mailbox>>> = Lock::new("mailbox", RefCell::new(None));
+static MAILBOX: Lock<Option<Mailbox>> = Lock::new("mailbox", None);
 
 /// Mailbox init.  Mainly initialises a lock to ensure only one mailbox request
 /// can be made at a time.  We have no heap at this point, so creating a mailbox
@@ -21,7 +20,7 @@ static MAILBOX: Lock<RefCell<Option<Mailbox>>> = Lock::new("mailbox", RefCell::n
 pub fn init(dt: &DeviceTree) {
     let node = LockNode::new();
     let mut mailbox = MAILBOX.lock(&node);
-    *mailbox = RefCell::new(Some(Mailbox::new(dt, KZERO)));
+    *mailbox = Some(Mailbox::new(dt, KZERO));
 }
 
 /// https://developer.arm.com/documentation/ddi0306/b/CHDGHAIG
@@ -122,7 +121,6 @@ where
     MAILBOX
         .lock(&node)
         .deref_mut()
-        .borrow_mut()
         .as_mut()
         .map(|mb| {
             mb.request(&mut msg);

--- a/aarch64/src/main.rs
+++ b/aarch64/src/main.rs
@@ -101,7 +101,6 @@ pub extern "C" fn main9(dtb_va: usize) {
     let dt = unsafe { DeviceTree::from_usize(dtb_va).unwrap() };
 
     // Set up uart so we can log as early as possible
-    mailbox::init(&dt);
     devcons::init(&dt);
 
     println!();
@@ -110,7 +109,6 @@ pub extern "C" fn main9(dtb_va: usize) {
     println!("midr_el1: {:?}", registers::MidrEl1::read());
 
     print_binary_sections();
-    print_board_info();
 
     pagealloc::init_page_allocator();
 
@@ -126,6 +124,8 @@ pub extern "C" fn main9(dtb_va: usize) {
 
     // From this point we can use the global allocator
 
+    mailbox::init(&dt);
+    print_board_info();
     print_memory_info();
 
     vmdebug::print_recursive_tables(RootPageTableType::Kernel);

--- a/aarch64/src/pagealloc.rs
+++ b/aarch64/src/pagealloc.rs
@@ -76,7 +76,7 @@ pub fn allocate_physpage() -> Result<PhysAddr, PageAllocError> {
 
     match page_alloc.allocate() {
         Ok(page_pa) => {
-            println!("pagealloc:allocate_physpage pa:{:?}", page_pa);
+            //println!("pagealloc:allocate_physpage pa:{:?}", page_pa);
             Ok(page_pa)
         }
         Err(err) => {
@@ -104,8 +104,8 @@ pub fn allocate_virtpage(
         crate::vm::PageSize::Page4K,
         pgtype,
     ) {
-        println!("pagealloc:allocate_virtpage:va:{:#x} -> physpage:{:?}", page_va.0, page_pa);
-        let virtpage = page_va.0 as *mut VirtPage4K;
+        // println!("pagealloc:allocate_virtpage:va:{:#x} -> physpage:{:?}", page_va.start(), page_pa);
+        let virtpage = page_va.start() as *mut VirtPage4K;
         Ok(unsafe { &mut *virtpage })
     } else {
         println!("error:pagealloc:allocate_virtpage:unable to map");

--- a/aarch64/src/registers.rs
+++ b/aarch64/src/registers.rs
@@ -5,7 +5,6 @@ use aarch64_cpu::registers::Readable;
 use bitstruct::bitstruct;
 use core::fmt;
 use num_enum::TryFromPrimitive;
-use port::mem::{PAGE_SIZE_2M, PhysRange};
 
 // GPIO registers
 pub const GPFSEL1: usize = 0x04; // GPIO function select register 1
@@ -80,23 +79,6 @@ pub enum PartNum {
     RaspberryPi2 = 0xc07,
     RaspberryPi3 = 0xd03,
     RaspberryPi4 = 0xd08,
-}
-
-impl PartNum {
-    /// Return the physical MMIO base range for the Raspberry Pi MMIO
-    pub fn mmio(&self) -> Option<PhysRange> {
-        let len = 2 * PAGE_SIZE_2M;
-        match self {
-            Self::RaspberryPi1 => Some(PhysRange::with_len(0x20000000, len)),
-            Self::RaspberryPi2 | Self::RaspberryPi3 => Some(PhysRange::with_len(0x3f000000, len)),
-            Self::RaspberryPi4 => Some(PhysRange::with_len(0xfe000000, len)),
-            Self::Unknown => None,
-        }
-    }
-}
-
-pub fn rpi_mmio() -> Option<PhysRange> {
-    MidrEl1::read().partnum_enum().ok().and_then(|p| p.mmio())
 }
 
 bitstruct! {

--- a/aarch64/src/uartmini.rs
+++ b/aarch64/src/uartmini.rs
@@ -1,85 +1,137 @@
+use port::Result;
 use port::devcons::Uart;
 use port::fdt::DeviceTree;
-use port::mem::VirtRange;
+use port::mem::{PhysRange, VirtRange};
 
+use crate::deviceutil::map_device_register;
 use crate::io::{delay, read_reg, write_or_reg, write_reg};
 use crate::registers::{
     AUX_ENABLE, AUX_MU_BAUD, AUX_MU_CNTL, AUX_MU_IER, AUX_MU_IIR, AUX_MU_IO, AUX_MU_LCR,
     AUX_MU_LSR, AUX_MU_MCR, GPFSEL1, GPPUD, GPPUDCLK0,
 };
+use crate::vm;
+
+#[cfg(not(test))]
+use port::println;
 
 /// MiniUart is assigned to UART1 on the Raspberry Pi.  It is easier to use with
 /// real hardware, as it requires no additional configuration.  Conversely, it's
 /// harded to use with QEMU, as it can't be used with the `nographic` switch.
 pub struct MiniUart {
-    pub gpio_range: VirtRange,
-    pub aux_range: VirtRange,
-    pub miniuart_range: VirtRange,
+    pub gpio_virtrange: VirtRange,
+    pub aux_virtrange: VirtRange,
+    pub miniuart_virtrange: VirtRange,
 }
 
 #[allow(dead_code)]
 impl MiniUart {
-    pub fn new(dt: &DeviceTree, mmio_virt_offset: usize) -> MiniUart {
-        // Bcm2835 and bcm2711 are essentially the same for our needs here.
-        // If fdt.rs supported aliases well, we could try to just look up 'gpio'.
-        let gpio_range = VirtRange::from(
-            &dt.find_compatible("brcm,bcm2835-gpio")
-                .next()
-                .or_else(|| dt.find_compatible("brcm,bcm2711-gpio").next())
-                .and_then(|uart| dt.property_translated_reg_iter(uart).next())
-                .and_then(|reg| reg.regblock())
-                .unwrap()
-                .with_offset(mmio_virt_offset as u64),
-        );
+    /// Create MiniUart assuming the required register have already been mapped.
+    /// This is intended for use only at early startup, *before* the full VM code has been set up,
+    /// and should be replaced by a MiniUart with specifically mapped ranges *after* the VM has
+    /// been set up.
+    pub fn new_assuming_mapped_mmio(dt: &DeviceTree, mmio_virt_offset: usize) -> Result<MiniUart> {
+        let gpio_virtrange = Self::find_gpio_physrange(dt)
+            .map(|pr| VirtRange::from_physrange(&pr, mmio_virt_offset))?;
 
-        // Find a compatible aux
-        let aux_range = VirtRange::from(
-            &dt.find_compatible("brcm,bcm2835-aux")
-                .next()
-                .and_then(|uart| dt.property_translated_reg_iter(uart).next())
-                .and_then(|reg| reg.regblock())
-                .unwrap()
-                .with_offset(mmio_virt_offset as u64),
-        );
+        let aux_virtrange = Self::find_aux_physrange(dt)
+            .map(|pr| VirtRange::from_physrange(&pr, mmio_virt_offset))?;
 
-        // Find a compatible miniuart
-        let miniuart_range = VirtRange::from(
-            &dt.find_compatible("brcm,bcm2835-aux-uart")
-                .next()
-                .and_then(|uart| dt.property_translated_reg_iter(uart).next())
-                .and_then(|reg| reg.regblock())
-                .unwrap()
-                .with_offset(mmio_virt_offset as u64),
-        );
+        let miniuart_virtrange = Self::find_miniuart_physrange(dt)
+            .map(|pr| VirtRange::from_physrange(&pr, mmio_virt_offset))?;
 
-        MiniUart { gpio_range, aux_range, miniuart_range }
+        Ok(MiniUart { gpio_virtrange, aux_virtrange, miniuart_virtrange })
+    }
+
+    pub fn new_with_map_ranges(dt: &DeviceTree) -> Result<MiniUart> {
+        let gpio_physrange = Self::find_gpio_physrange(dt)?;
+        let gpio_virtrange = match map_device_register("gpio", gpio_physrange, vm::PageSize::Page4K)
+        {
+            Ok(gpio_virtrange) => gpio_virtrange,
+            Err(msg) => {
+                println!("can't map gpio {:?}", msg);
+                return Err("can't create miniuart");
+            }
+        };
+
+        let aux_physrange = Self::find_aux_physrange(dt)?;
+        let aux_virtrange = match map_device_register("aux", aux_physrange, vm::PageSize::Page4K) {
+            Ok(aux_virtrange) => aux_virtrange,
+            Err(msg) => {
+                println!("can't map aux {:?}", msg);
+                return Err("can't create miniuart");
+            }
+        };
+
+        let miniuart_physrange = Self::find_miniuart_physrange(dt)?;
+        let miniuart_virtrange =
+            match map_device_register("miniuart", miniuart_physrange, vm::PageSize::Page4K) {
+                Ok(aux_virtrange) => aux_virtrange,
+                Err(msg) => {
+                    println!("can't map miniuart {:?}", msg);
+                    return Err("can't create miniuart");
+                }
+            };
+
+        Ok(MiniUart { gpio_virtrange, aux_virtrange, miniuart_virtrange })
+    }
+
+    /// Bcm2835 and bcm2711 are essentially the same for our needs here.
+    /// If fdt.rs supported aliases well, we could try to just look up 'gpio'.
+    fn find_gpio_physrange(dt: &DeviceTree) -> Result<PhysRange> {
+        dt.find_compatible("brcm,bcm2835-gpio")
+            .next()
+            .or_else(|| dt.find_compatible("brcm,bcm2711-gpio").next())
+            .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+            .and_then(|reg| reg.regblock())
+            .map(|reg| PhysRange::from(&reg))
+            .ok_or("can't find gpio")
+    }
+
+    /// Find a compatible aux
+    fn find_aux_physrange(dt: &DeviceTree) -> Result<PhysRange> {
+        dt.find_compatible("brcm,bcm2835-aux")
+            .next()
+            .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+            .and_then(|reg| reg.regblock())
+            .map(|reg| PhysRange::from(&reg))
+            .ok_or("can't find aux")
+    }
+
+    /// Find a compatible miniuart
+    fn find_miniuart_physrange(dt: &DeviceTree) -> Result<PhysRange> {
+        dt.find_compatible("brcm,bcm2835-aux-uart")
+            .next()
+            .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+            .and_then(|reg| reg.regblock())
+            .map(|reg| PhysRange::from(&reg))
+            .ok_or("can't find miniuart")
     }
 
     pub fn init(&self) {
         // Set GPIO pins 14 and 15 to be used for UART1.  This is done by
         // setting the appropriate flags in GPFSEL1 to ALT5, which is
         // represented by the 0b010
-        let mut gpfsel1 = read_reg(&self.gpio_range, GPFSEL1);
+        let mut gpfsel1 = read_reg(&self.gpio_virtrange, GPFSEL1);
         gpfsel1 &= !((7 << 12) | (7 << 15));
         gpfsel1 |= (2 << 12) | (2 << 15);
-        write_reg(&self.gpio_range, GPFSEL1, gpfsel1);
+        write_reg(&self.gpio_virtrange, GPFSEL1, gpfsel1);
 
-        write_reg(&self.gpio_range, GPPUD, 0);
+        write_reg(&self.gpio_virtrange, GPPUD, 0);
         delay(150);
-        write_reg(&self.gpio_range, GPPUDCLK0, (1 << 14) | (1 << 15));
+        write_reg(&self.gpio_virtrange, GPPUDCLK0, (1 << 14) | (1 << 15));
         delay(150);
-        write_reg(&self.gpio_range, GPPUDCLK0, 0);
+        write_reg(&self.gpio_virtrange, GPPUDCLK0, 0);
 
         // Enable mini uart - required to write to its registers
-        write_or_reg(&self.aux_range, AUX_ENABLE, 1);
-        write_reg(&self.miniuart_range, AUX_MU_CNTL, 0);
+        write_or_reg(&self.aux_virtrange, AUX_ENABLE, 1);
+        write_reg(&self.miniuart_virtrange, AUX_MU_CNTL, 0);
         // 8-bit
-        write_reg(&self.miniuart_range, AUX_MU_LCR, 3);
-        write_reg(&self.miniuart_range, AUX_MU_MCR, 0);
+        write_reg(&self.miniuart_virtrange, AUX_MU_LCR, 3);
+        write_reg(&self.miniuart_virtrange, AUX_MU_MCR, 0);
         // Disable interrupts
-        write_reg(&self.miniuart_range, AUX_MU_IER, 0);
+        write_reg(&self.miniuart_virtrange, AUX_MU_IER, 0);
         // Clear receive/transmit FIFOs
-        write_reg(&self.miniuart_range, AUX_MU_IIR, 0xc6);
+        write_reg(&self.miniuart_virtrange, AUX_MU_IIR, 0xc6);
 
         // We want 115200 baud.  This is calculated as:
         //   system_clock_freq / (8 * (baudrate_reg + 1))
@@ -88,19 +140,19 @@ impl MiniUart {
         // let arm_clock_rate = 500000000.0;
         // let baud_rate_reg = arm_clock_rate / (8.0 * 115200.0) + 1.0;
         //write_reg(self.miniuart_reg, AUX_MU_BAUD, baud_rate_reg as u32);
-        write_reg(&self.miniuart_range, AUX_MU_BAUD, 270);
+        write_reg(&self.miniuart_virtrange, AUX_MU_BAUD, 270);
 
         // Finally enable transmit
-        write_reg(&self.miniuart_range, AUX_MU_CNTL, 3);
+        write_reg(&self.miniuart_virtrange, AUX_MU_CNTL, 3);
     }
 }
 
 impl Uart for MiniUart {
     fn putb(&self, b: u8) {
         // Wait for UART to become ready to transmit
-        while read_reg(&self.miniuart_range, AUX_MU_LSR) & (1 << 5) == 0 {
+        while read_reg(&self.miniuart_virtrange, AUX_MU_LSR) & (1 << 5) == 0 {
             core::hint::spin_loop();
         }
-        write_reg(&self.miniuart_range, AUX_MU_IO, b as u32);
+        write_reg(&self.miniuart_virtrange, AUX_MU_IO, b as u32);
     }
 }

--- a/aarch64/src/uartpl011.rs
+++ b/aarch64/src/uartpl011.rs
@@ -1,17 +1,22 @@
-use crate::io::{delay, read_reg, write_reg, GpioPull};
-use crate::mailbox;
+use crate::deviceutil::map_device_register;
+use crate::io::{GpioPull, delay, read_reg, write_reg};
 use crate::registers::{
     GPPUD, GPPUDCLK0, UART0_CR, UART0_DR, UART0_FBRD, UART0_FR, UART0_IBRD, UART0_ICR, UART0_IMSC,
     UART0_LCRH,
 };
+use crate::{mailbox, vm};
+use port::Result;
 use port::devcons::Uart;
 use port::fdt::DeviceTree;
-use port::mem::VirtRange;
+use port::mem::{PhysRange, VirtRange};
+
+#[cfg(not(test))]
+use port::println;
 
 #[allow(dead_code)]
 pub struct Pl011Uart {
-    gpio_range: VirtRange,
-    pl011_range: VirtRange,
+    gpio_virtrange: VirtRange,
+    pl011_virtrange: VirtRange,
 }
 
 /// PL011 is the default in qemu (UART0), but a bit fiddly to use on a real
@@ -19,38 +24,58 @@ pub struct Pl011Uart {
 /// and EEPROM (rpi4) to assign to the serial GPIO pins.
 #[allow(dead_code)]
 impl Pl011Uart {
-    pub fn new(dt: &DeviceTree) -> Pl011Uart {
-        // TODO use aliases?
-        let gpio_range = VirtRange::from(
-            &dt.find_compatible("brcm,bcm2835-gpio")
-                .next()
-                .and_then(|uart| dt.property_translated_reg_iter(uart).next())
-                .and_then(|reg| reg.regblock())
-                .unwrap(),
-        );
+    pub fn new(dt: &DeviceTree) -> Result<Pl011Uart> {
+        let gpio_physrange = Self::find_gpio_physrange(dt)?;
+        let gpio_virtrange = match map_device_register("gpio", gpio_physrange, vm::PageSize::Page4K)
+        {
+            Ok(gpio_virtrange) => gpio_virtrange,
+            Err(msg) => {
+                println!("can't map gpio {:?}", msg);
+                return Err("can't create pl011");
+            }
+        };
 
-        // Find a compatible pl011 uart
-        let pl011_range = VirtRange::from(
-            &dt.find_compatible("arm,pl011")
-                .next()
-                .and_then(|uart| dt.property_translated_reg_iter(uart).next())
-                .and_then(|reg| reg.regblock())
-                .unwrap(),
-        );
+        let pl011_physrange = Self::find_pl011_physrange(dt)?;
+        let pl011_virtrange =
+            match map_device_register("pl011", pl011_physrange, vm::PageSize::Page4K) {
+                Ok(pl011_virtrange) => pl011_virtrange,
+                Err(msg) => {
+                    println!("can't map pl011 {:?}", msg);
+                    return Err("can't create pl011");
+                }
+            };
 
-        Pl011Uart { gpio_range, pl011_range }
+        Ok(Pl011Uart { gpio_virtrange, pl011_virtrange })
+    }
+
+    fn find_gpio_physrange(dt: &DeviceTree) -> Result<PhysRange> {
+        dt.find_compatible("brcm,bcm2835-gpio")
+            .next()
+            .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+            .and_then(|reg| reg.regblock())
+            .map(|reg| PhysRange::from(&reg))
+            .ok_or("can't find gpio")
+    }
+
+    fn find_pl011_physrange(dt: &DeviceTree) -> Result<PhysRange> {
+        dt.find_compatible("arm,pl011")
+            .next()
+            .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+            .and_then(|reg| reg.regblock())
+            .map(|reg| PhysRange::from(&reg))
+            .ok_or("can't find pl011")
     }
 
     pub fn init(&self) {
         // Disable UART0
-        write_reg(&self.pl011_range, UART0_CR, 0);
+        write_reg(&self.pl011_virtrange, UART0_CR, 0);
 
         // Turn pull up/down off for pins 14/15 (tx/rx)
         self.gpiosetpull(14, GpioPull::Off);
         self.gpiosetpull(15, GpioPull::Off);
 
         // Clear interrupts
-        write_reg(&self.pl011_range, UART0_ICR, 0x7ff);
+        write_reg(&self.pl011_virtrange, UART0_ICR, 0x7ff);
 
         // Set the uart clock rate to 3MHz
         let uart_clock_rate_hz = 3_000_000;
@@ -61,17 +86,17 @@ impl Pl011Uart {
         let baud_rate_divisor = (uart_clock_rate_hz as f32) / ((16 * baud_rate) as f32);
         let int_brd = baud_rate_divisor as u32;
         let frac_brd = (((baud_rate_divisor - (int_brd as f32)) * 64.0) + 0.5) as u32;
-        write_reg(&self.pl011_range, UART0_IBRD, int_brd);
-        write_reg(&self.pl011_range, UART0_FBRD, frac_brd);
+        write_reg(&self.pl011_virtrange, UART0_IBRD, int_brd);
+        write_reg(&self.pl011_virtrange, UART0_FBRD, frac_brd);
 
         // Enable FIFOs (tx and rx), 8 bit
-        write_reg(&self.pl011_range, UART0_LCRH, 0x70);
+        write_reg(&self.pl011_virtrange, UART0_LCRH, 0x70);
 
         // Mask all interrupts
-        write_reg(&self.pl011_range, UART0_IMSC, 0x7f2);
+        write_reg(&self.pl011_virtrange, UART0_IMSC, 0x7f2);
 
         // Enable UART0, receive only
-        write_reg(&self.pl011_range, UART0_CR, 0x81);
+        write_reg(&self.pl011_virtrange, UART0_CR, 0x81);
     }
 
     fn gpiosetpull(&self, pin: u32, pull: GpioPull) {
@@ -85,23 +110,23 @@ impl Pl011Uart {
         let gppudclk_reg = GPPUDCLK0 + reg_offset * 4;
 
         // You can't read the GPPUD registers, so to set the state we first set the PUD value we want...
-        write_reg(&self.pl011_range, GPPUD, pull as u32);
+        write_reg(&self.pl011_virtrange, GPPUD, pull as u32);
         // ...wait 150 cycles for it to set
         delay(150);
         // ...set the appropriate PUD bit
-        write_reg(&self.pl011_range, gppudclk_reg, pud_bit);
+        write_reg(&self.pl011_virtrange, gppudclk_reg, pud_bit);
         // ...wait 150 cycles for it to set
         delay(150);
         // ...clear up
-        write_reg(&self.pl011_range, GPPUD, 0);
-        write_reg(&self.pl011_range, gppudclk_reg, 0);
+        write_reg(&self.pl011_virtrange, GPPUD, 0);
+        write_reg(&self.pl011_virtrange, gppudclk_reg, 0);
     }
 }
 
 impl Uart for Pl011Uart {
     fn putb(&self, b: u8) {
         // Wait for UART to become ready to transmit.
-        while read_reg(&self.pl011_range, UART0_FR) & (1 << 5) != 0 {}
-        write_reg(&self.pl011_range, UART0_DR, b as u32);
+        while read_reg(&self.pl011_virtrange, UART0_FR) & (1 << 5) != 0 {}
+        write_reg(&self.pl011_virtrange, UART0_DR, b as u32);
     }
 }

--- a/port/src/lib.rs
+++ b/port/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(allocator_api)]
 #![feature(maybe_uninit_slice)]
 #![feature(step_trait)]
-#![feature(unsigned_is_multiple_of)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 
 extern crate alloc;
@@ -14,6 +13,9 @@ pub mod bitmapalloc;
 pub mod dat;
 pub mod devcons;
 pub mod fdt;
+pub mod maths;
 pub mod mcslock;
 pub mod mem;
 pub mod pagealloc;
+
+pub type Result<T> = core::result::Result<T, &'static str>;

--- a/port/src/maths.rs
+++ b/port/src/maths.rs
@@ -28,7 +28,7 @@ mod tests {
 
     #[test]
     fn test_round_up2() {
-        assert_eq!(round_up2_usize(0, 16), 16);
+        assert_eq!(round_up2_usize(0, 16), 0);
         assert_eq!(round_up2_usize(6, 16), 16);
         assert_eq!(round_up2_usize(16, 16), 16);
         assert_eq!(round_up2_usize(17, 16), 32);
@@ -39,7 +39,7 @@ mod tests {
     fn test_round_down2() {
         assert_eq!(round_down2_usize(0, 16), 0);
         assert_eq!(round_down2_usize(6, 16), 0);
-        assert_eq!(round_down2_usize(16, 16), 0);
+        assert_eq!(round_down2_usize(16, 16), 16);
         assert_eq!(round_down2_usize(17, 16), 16);
         assert_eq!(round_down2_usize(8193, 4096), 8192);
     }

--- a/port/src/maths.rs
+++ b/port/src/maths.rs
@@ -1,0 +1,46 @@
+/// Round up by a power of 2
+pub const fn round_up2_usize(n: usize, step: usize) -> usize {
+    assert!(step.is_power_of_two());
+    (n + step - 1) & !(step - 1)
+}
+
+/// Round down by a power of 2
+pub const fn round_down2_usize(n: usize, step: usize) -> usize {
+    assert!(step.is_power_of_two());
+    n & !(step - 1)
+}
+
+/// Round up by a power of 2
+pub const fn round_up2_u64(n: u64, step: u64) -> u64 {
+    assert!(step.is_power_of_two());
+    (n + step - 1) & !(step - 1)
+}
+
+/// Round down by a power of 2
+pub const fn round_down2_u64(n: u64, step: u64) -> u64 {
+    assert!(step.is_power_of_two());
+    n & !(step - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_up2() {
+        assert_eq!(round_up2_usize(0, 16), 16);
+        assert_eq!(round_up2_usize(6, 16), 16);
+        assert_eq!(round_up2_usize(16, 16), 16);
+        assert_eq!(round_up2_usize(17, 16), 32);
+        assert_eq!(round_up2_usize(8193, 4096), 12288);
+    }
+
+    #[test]
+    fn test_round_down2() {
+        assert_eq!(round_down2_usize(0, 16), 0);
+        assert_eq!(round_down2_usize(6, 16), 0);
+        assert_eq!(round_down2_usize(16, 16), 0);
+        assert_eq!(round_down2_usize(17, 16), 16);
+        assert_eq!(round_down2_usize(8193, 4096), 8192);
+    }
+}

--- a/riscv64/src/platform/nezha/devcons.rs
+++ b/riscv64/src/platform/nezha/devcons.rs
@@ -21,7 +21,7 @@ pub fn init(dt: &DeviceTree) {
 
         unsafe {
             UART.write(uart);
-            UART.assume_init_mut()
+            Ok(UART.assume_init_mut())
         }
     });
 }

--- a/riscv64/src/platform/virt/devcons.rs
+++ b/riscv64/src/platform/virt/devcons.rs
@@ -14,7 +14,7 @@ pub fn init(dt: &DeviceTree) {
         .and_then(|reg| reg.regblock())
         .unwrap();
 
-    Console::new(|| {
+    Console::set_uart(|| {
         let mut uart = Uart16550::new(ns16550a_reg);
         uart.init(115_200);
 
@@ -23,7 +23,7 @@ pub fn init(dt: &DeviceTree) {
         unsafe {
             let cons = &mut *CONS.get();
             cons.write(uart);
-            cons.assume_init_mut()
+            Ok(cons.assume_init_mut())
         }
     });
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-04-15"
+channel = "nightly-2025-04-30"
 components = ["rustfmt", "rust-src", "clippy", "llvm-tools"]
 targets = [
     "aarch64-unknown-none",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-02-22"
+channel = "nightly-2025-04-15"
 components = ["rustfmt", "rust-src", "clippy", "llvm-tools"]
 targets = [
     "aarch64-unknown-none",

--- a/x86_64/src/devcons.rs
+++ b/x86_64/src/devcons.rs
@@ -14,8 +14,8 @@ impl Uart for Uart16550 {
 }
 
 pub fn init() {
-    Console::new(|| {
+    Console::set_uart(|| {
         static CONS: SyncUnsafeCell<Uart16550> = SyncUnsafeCell::new(Uart16550 { port: 0x3f8 });
-        unsafe { &mut *CONS.get() }
+        unsafe { Ok(&mut *CONS.get()) }
     });
 }

--- a/x86_64/src/main.rs
+++ b/x86_64/src/main.rs
@@ -1,5 +1,4 @@
 #![feature(alloc_error_handler)]
-#![feature(naked_functions)]
 #![feature(sync_unsafe_cell)]
 #![cfg_attr(not(any(test)), no_std)]
 #![cfg_attr(not(test), no_main)]

--- a/x86_64/src/proc.rs
+++ b/x86_64/src/proc.rs
@@ -18,11 +18,10 @@ impl Label {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 pub unsafe extern "C" fn swtch(save: &mut Label, next: &mut Label) {
-    unsafe {
-        naked_asm!(
-            r#"
+    naked_asm!(
+        r#"
             movq (%rsp), %rax
             movq %rax, 0(%rdi)
             movq %rsp, 8(%rdi)
@@ -44,7 +43,6 @@ pub unsafe extern "C" fn swtch(save: &mut Label, next: &mut Label) {
             movq %rax, (%rsp)
             xorl %eax, %eax
             ret"#,
-            options(att_syntax)
-        );
-    }
+        options(att_syntax)
+    );
 }

--- a/xtask/src/config.rs
+++ b/xtask/src/config.rs
@@ -5,7 +5,7 @@ use crate::{Command, Profile};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    fs::{self, create_dir_all, File},
+    fs::{self, File, create_dir_all},
     io::Write,
     process::exit,
 };
@@ -100,7 +100,7 @@ impl Configuration {
         let config: Configuration = match toml::from_str(&contents) {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("TOML: Unable to load data from `{}`", filename);
+                eprintln!("TOML: Unable to load data from `{filename}`");
                 eprintln!("{e}");
                 exit(1);
             }
@@ -143,7 +143,7 @@ fn apply_platform_config(cmd: &mut Command, rustflags: &mut Vec<String>, config:
 
         if let Some(platform) = &config.platform {
             rustflags.push("--cfg".into());
-            rustflags.push(format!("platform=\"{}\"", platform));
+            rustflags.push(format!("platform=\"{platform}\""));
         }
 
         if let Some(devices) = &config.dev {
@@ -210,8 +210,7 @@ fn apply_link(
 
         // do we have a linker script ?
         if !filename.is_empty() {
-            let mut contents = match fs::read_to_string(format!("{}/{}", workspace_path, filename))
-            {
+            let mut contents = match fs::read_to_string(format!("{workspace_path}/{filename}")) {
                 Ok(c) => c,
                 Err(_) => {
                     eprintln!("Could not read file `{filename}`");
@@ -247,11 +246,11 @@ fn apply_link(
 
             // everything is setup, now create the linker script
             // in the target directory
-            let mut file = File::create(format!("{}/kernel.ld", path)).unwrap();
+            let mut file = File::create(format!("{path}/kernel.ld")).unwrap();
             let _ = file.write_all(contents.as_bytes());
 
             // pass the script path to the rustflags
-            rustflags.push(format!("-Clink-args=-T{}/kernel.ld", path));
+            rustflags.push(format!("-Clink-args=-T{path}/kernel.ld"));
         }
     }
 }
@@ -275,7 +274,7 @@ fn apply_rustflags(cmd: &mut Command, rustflags: &[String]) {
     if !rustflags.is_empty() {
         let flat = rustflags.join(" ");
         cmd.arg("--config");
-        cmd.arg(format!("build.rustflags='{}'", flat));
+        cmd.arg(format!("build.rustflags='{flat}'"));
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,11 +21,7 @@ pub enum Profile {
 
 impl Profile {
     fn from(matches: &clap::ArgMatches) -> Self {
-        if matches.get_flag("release") {
-            Profile::Release
-        } else {
-            Profile::Debug
-        }
+        if matches.get_flag("release") { Profile::Release } else { Profile::Debug }
     }
 
     fn dir(&self) -> &'static str {
@@ -493,7 +489,7 @@ impl QemuStep {
                 cmd.arg("-d");
                 cmd.arg("int");
                 cmd.arg("-kernel");
-                cmd.arg(format!("target/{}/{}/aarch64-qemu.gz", target, dir));
+                cmd.arg(format!("target/{target}/{dir}/aarch64-qemu.gz"));
                 cmd.current_dir(workspace());
                 if self.verbose {
                     println!("Executing {cmd:?}");
@@ -531,7 +527,7 @@ impl QemuStep {
                 }
                 cmd.arg("-d").arg("guest_errors,unimp");
                 cmd.arg("-kernel");
-                cmd.arg(format!("target/{}/{}/riscv64", target, dir));
+                cmd.arg(format!("target/{target}/{dir}/riscv64"));
                 cmd.current_dir(workspace());
                 if self.verbose {
                     println!("Executing {cmd:?}");
@@ -567,7 +563,7 @@ impl QemuStep {
                 //cmd.arg("-device");
                 //cmd.arg("ide-hd,drive=sdahci0,bus=ahci0.0");
                 cmd.arg("-kernel");
-                cmd.arg(format!("target/{}/{}/r9.elf32", target, dir));
+                cmd.arg(format!("target/{target}/{dir}/r9.elf32"));
                 cmd.current_dir(workspace());
                 if self.verbose {
                     println!("Executing {cmd:?}");


### PR DESCRIPTION
Originally the code relied on the rpi MMIO being bulk mapped when the VM was set up.  This doesn't help for device registers outside that region.  So now each device (mainly uart and mailbox atm) maps registers as needed.  This is done in a simple way (just iterate through a large virtual area for the device registers) but it's fine for now.

This requires us to change a lot of the initialisation code.

Also took the opportunity to tidy the logging and update rust.