### PR TITLE
Mark rpi mailbox buffer as device memory

### DIFF
--- a/aarch64/src/deviceutil.rs
+++ b/aarch64/src/deviceutil.rs
@@ -1,7 +1,7 @@
 use port::Result;
 use port::mem::{PhysRange, VirtRange};
 
-use crate::vm;
+use crate::{pagealloc, vm};
 
 /// Map a device register to device memory
 /// TODO Maybe make this a macro and wrap the error reporting?
@@ -24,5 +24,28 @@ pub fn map_device_register(
         Ok(VirtRange::from_physrange(&physrange, offset))
     } else {
         Err("failed to map device register")
+    }
+}
+
+/// Map a buffer to device memory
+/// TODO Maybe make this a macro and wrap the error reporting?
+pub fn alloc_device_page(
+    id: &'static str,
+    page_size: vm::PageSize,
+) -> Result<(VirtRange, PhysRange)> {
+    let page_pa = pagealloc::allocate_physpage().expect("couldn't allocate page");
+    let page_physrange = PhysRange::with_pa_len(page_pa, page_size.size());
+
+    if let Ok(vr) = vm::kernel_pagetable().map_phys_range(
+        id,
+        &page_physrange,
+        vm::next_free_device_page4k(),
+        vm::Entry::rw_device(),
+        page_size,
+        vm::RootPageTableType::Kernel,
+    ) {
+        Ok((vr, page_physrange))
+    } else {
+        Err("failed to map device buffer")
     }
 }

--- a/aarch64/src/mailbox.rs
+++ b/aarch64/src/mailbox.rs
@@ -1,4 +1,6 @@
-use crate::deviceutil::map_device_register;
+use core::ptr::NonNull;
+
+use crate::deviceutil::{self, map_device_register};
 use crate::io::{read_reg, write_reg};
 use crate::vm;
 use port::Result;
@@ -37,18 +39,27 @@ pub fn init(dt: &DeviceTree) {
 /// https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
 struct Mailbox {
     pub mbox_virtrange: VirtRange,
+    req_buffer_va: VirtRange,
+    req_buffer_pa: PhysRange,
 }
 
 impl Mailbox {
     fn new(dt: &DeviceTree) -> Result<Self> {
+        // Allocate a page of device memory for the mailbox request/response buffer
+        // TODO Split this into multiple buffers to allow parallel requests.
+        let (req_buffer_va, req_buffer_pa) =
+            deviceutil::alloc_device_page("mailboxbuf", vm::PageSize::Page4K)?;
+
         let mbox_physrange = Self::find_mbox_physrange(dt)?;
-        match map_device_register("mailbox", mbox_physrange, vm::PageSize::Page4K) {
-            Ok(mbox_virtrange) => Ok(Mailbox { mbox_virtrange }),
+        let mbox = match map_device_register("mailbox", mbox_physrange, vm::PageSize::Page4K) {
+            Ok(mbox_virtrange) => Ok(Mailbox { mbox_virtrange, req_buffer_va, req_buffer_pa }),
             Err(msg) => {
                 println!("can't map mailbox {:?}", msg);
                 Err("can't create mailbox")
             }
-        }
+        }?;
+
+        Ok(mbox)
     }
 
     /// Get the physical range required for this device
@@ -61,7 +72,7 @@ impl Mailbox {
             .ok_or("can't find mbox")
     }
 
-    fn request<T, U>(&self, req: &mut Message<T, U>)
+    fn request<T, U>(&self)
     where
         T: Copy,
         U: Copy,
@@ -71,12 +82,12 @@ impl Mailbox {
 
         // Write the request address combined with the channel to the write register
         let channel = ChannelId::ArmToVc as u32;
-        let uart_mbox_u32 = req as *const _ as u32;
+        let uart_mbox_u32 = self.req_buffer_pa.start().addr() as u32;
         let r = (uart_mbox_u32 & !0xF) | channel;
         write_reg(&self.mbox_virtrange, MBOX_WRITE, r);
 
         // Wait for response
-        // FIXME: two infinite loops - can go awry
+        // FIXME: two infinite loops - could go awry
         loop {
             while (read_reg(&self.mbox_virtrange, MBOX_STATUS) & MBOX_EMPTY) != 0 {}
             let response = read_reg(&self.mbox_virtrange, MBOX_READ);
@@ -133,14 +144,22 @@ where
     U: Copy,
 {
     let size = size_of::<Message<T, U>>() as u32;
-    let req = Request::<Tag<T>> { size, code, tags: *tags };
-    let mut msg = MessageWithTags { request: req };
     let node = LockNode::new();
     MAILBOX
         .lock(&node)
         .as_mut()
         .map(|mb| {
-            mb.request(&mut msg);
+            let msg = unsafe {
+                let page_va_ptr = mb.req_buffer_va.start() as u64 as *mut MessageWithTags<T, U>;
+                core::intrinsics::volatile_set_memory(page_va_ptr, 0, 1);
+                let msg = NonNull::new_unchecked(page_va_ptr).as_mut();
+                msg.request.size = size;
+                msg.request.code = code;
+                msg.request.tags = *tags;
+                msg
+            };
+
+            mb.request::<T, U>();
             unsafe { msg.response.tags.body }
         })
         .expect("mailbox not initialised")

--- a/aarch64/src/uartmini.rs
+++ b/aarch64/src/uartmini.rs
@@ -138,9 +138,9 @@ impl MiniUart {
         // For now we're making assumptions about the clock frequency
         // TODO Get the clock freq via the mailbox, and update if it changes.
         // let arm_clock_rate = 500000000.0;
-        // let baud_rate_reg = arm_clock_rate / (8.0 * 115200.0) + 1.0;
+        // let baud_rate_reg = arm_clock_rate / (8.0 * 115200.0) - 1.0;
         //write_reg(self.miniuart_reg, AUX_MU_BAUD, baud_rate_reg as u32);
-        write_reg(&self.miniuart_virtrange, AUX_MU_BAUD, 270);
+        write_reg(&self.miniuart_virtrange, AUX_MU_BAUD, 545);
 
         // Finally enable transmit
         write_reg(&self.miniuart_virtrange, AUX_MU_CNTL, 3);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-06-09"
+channel = "nightly-2025-06-20"
 components = ["rustfmt", "rust-src", "clippy", "llvm-tools"]
 targets = [
     "aarch64-unknown-none",


### PR DESCRIPTION
Qemu doesn't care, but the real rpi expects the mailbox buffer to be device memory, so we allocate a page of device mem for its use.  This makes sense as the mailbox device will write its response back to the memory at some point after the request is written by the CPU. Also bump rust while we're at it.