### PR TITLE
traps: Implement exception handling for x86_64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -38,44 +38,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
 [[package]]
 name = "bit_field"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -85,9 +85,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitstruct"
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -133,27 +133,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "equivalent"
@@ -163,9 +163,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -175,9 +175,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -190,58 +190,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.3"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "port"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -264,6 +259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "sbi-rt"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,33 +280,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
-name = "serde"
-version = "1.0.218"
+name = "seq-macro"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
+name = "serde"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
- "serde",
+ "serde_core",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -326,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -337,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tock-registers"
@@ -349,43 +372,48 @@ checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.17"
+name = "toml_datetime"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "utf8parse"
@@ -394,20 +422,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
+name = "windows-link"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -420,60 +455,57 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
-dependencies = [
- "memchr",
-]
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "x86"
@@ -490,9 +522,13 @@ dependencies = [
 name = "x86_64"
 version = "0.1.0"
 dependencies = [
+ "bit_field",
  "bitstruct",
  "port",
+ "seq-macro",
+ "static_assertions",
  "x86",
+ "zerocopy",
 ]
 
 [[package]]
@@ -503,4 +539,24 @@ dependencies = [
  "serde",
  "target-lexicon",
  "toml",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]

--- a/lib/aarch64-unknown-none-elf.json
+++ b/lib/aarch64-unknown-none-elf.json
@@ -10,7 +10,7 @@
   "max-atomic-width": 128,
   "panic-strategy": "abort",
   "relocation-model": "pie",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "pre-link-args": {
     "ld.lld": ["-nostdlib"]
   }

--- a/lib/riscv64-unknown-none-elf.json
+++ b/lib/riscv64-unknown-none-elf.json
@@ -6,7 +6,6 @@
 	"eh-frame-header": false,
 	"emit-debug-gdb-scripts": false,
 	"features": "+m,+a,+f,+d,+c",
-	"is-builtin": false,
 	"linker": "rust-lld",
 	"linker-flavor": "ld.lld",
 	"llvm-abiname": "lp64d",
@@ -14,7 +13,7 @@
 	"max-atomic-width": 64,
 	"panic-strategy": "abort",
 	"relocation-model": "pie",
-	"target-pointer-width": "64",
+	"target-pointer-width": 64,
 	"pre-link-args": {
 		"ld.lld": [
 			"-nostdlib"

--- a/lib/x86_64-unknown-none-elf.json
+++ b/lib/x86_64-unknown-none-elf.json
@@ -1,22 +1,22 @@
 {
-  "llvm-target": "x86_64-unknown-none-elf",
-  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
-  "linker-flavor": "ld.lld",
-  "linker": "rust-lld",
-  "target-endian": "little",
-  "target-pointer-width": "64",
-  "target-c-int-width": "32",
-  "arch": "x86_64",
-  "os": "none",
-  "executables": true,
-  "relocation-model": "pie",
-  "code-model": "medium",
-  "disable-redzone": true,
-  "features": "-mmx,-sse,+soft-float",
-  "panic-strategy": "abort",
-  "frame-pointer": "always",
-  "pre-link-args": {
-    "ld.lld": ["-nostdlib"]
-  },
-  "rustc-abi": "x86-softfloat"
+    "llvm-target": "x86_64-unknown-none-elf",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "target-endian": "little",
+    "target-pointer-width": 64,
+    "target-c-int-width": 32,
+    "arch": "x86_64",
+    "os": "none",
+    "executables": true,
+    "relocation-model": "static",
+    "code-model": "kernel",
+    "disable-redzone": true,
+    "features": "-mmx,-sse,+soft-float",
+    "panic-strategy": "abort",
+    "frame-pointer": "always",
+    "pre-link-args": {
+        "ld.lld": ["-nostdlib"]
+    },
+    "rustc-abi": "x86-softfloat"
 }

--- a/port/src/dat.rs
+++ b/port/src/dat.rs
@@ -97,3 +97,5 @@ pub struct Walkqid {
     _clone: Arc<Chan>,
     _qids: [Qid],
 }
+
+pub struct Proc {}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-06-20"
+channel = "nightly-2025-09-20"
 components = ["rustfmt", "rust-src", "clippy", "llvm-tools"]
 targets = [
     "aarch64-unknown-none",

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -10,3 +10,7 @@ default-target = "x86_64-unknown-none"
 bitstruct = "0.1"
 x86 = "0.52"
 port = { path = "../port" }
+seq-macro = "0.3.6"
+zerocopy = { version = "0.8.27", features = ["derive"] }
+bit_field = "0.10.3"
+static_assertions = "1.1.0"

--- a/x86_64/lib/config_default.toml
+++ b/x86_64/lib/config_default.toml
@@ -6,5 +6,4 @@ buildflags = [
 
 [link]
 script = 'x86_64/lib/kernel.ld'
-load-address = '0xffff800000100000'
-
+load-address = '0xffffffff80200000'

--- a/x86_64/lib/kernel.ld
+++ b/x86_64/lib/kernel.ld
@@ -3,56 +3,46 @@
  */
 
 ENTRY(start)
+KZERO = 0xffffffff80000000;
 
 SECTIONS {
 	/*
-	 * start the kernel at 0x0xffff_8000_0020_0000
+	 * start the kernel at 0x0xffff_ffff_8020_0000
 	 * This preserves some RAM between 1MiB and the
 	 * start of the kernel for critical structures.
 	 */
 	. = ${LOAD-ADDRESS};
 
-	PROVIDE(boottext = .);
-	.text.boot : ALIGN(4096) {
-		*(.boottext .bootdata)
-		. = ALIGN(4096);
-		PROVIDE(eboottext = .);
-		. = ALIGN(2097152);
-		PROVIDE(esys = .);
-	}
-
 	PROVIDE(text = .);
-	.text : ALIGN(4096) {
-		*(.text* .stub .gnu.linkonce.t.*)
+	.text : AT (ADDR(.text) - KZERO) {
+		*(.text.boot)
+		*(.*text* .stub .gnu.linkonce.t.*)
+		. = ALIGN(4096);
+		*(.trap*)
 		. = ALIGN(2097152);
 		PROVIDE(etext = .);
 	}
 
-	.rodata : ALIGN(4096) {
-		*(.rodata* .gnu.linkonce.r.*)
+	.rodata : AT (ADDR(.rodata) - KZERO) {
+		*(.*rodata* .gnu.linkonce.r.*)
 		. = ALIGN(2097152);
 		PROVIDE(erodata = .);
 	}
 
-	.data : ALIGN(4096) {
-		*(.data*)
-	}
-	.got : ALIGN(4096) {
-		*(.got)
-	}
-	.got.plt : ALIGN(4096) {
-		*(.got.plt)
+	.data : AT (ADDR(.data) - KZERO) {
+		*(.*data*)
+		. = ALIGN(4096);
 	}
 	PROVIDE(edata = .);
 
-	.bss : ALIGN(4096) {
-		*(.bss*)
+	.bss : AT (ADDR(.bss) - KZERO) {
 		*(COMMON)
+		*(.*bss*)
 		. = ALIGN(2097152);
 	}
 	PROVIDE(end = .);
 
 	/DISCARD/ : {
-		*(.eh_frame .note.GNU-stack)
+		*(.eh_frame* .note* .got*)
 	}
 }

--- a/x86_64/src/cpu.rs
+++ b/x86_64/src/cpu.rs
@@ -1,0 +1,147 @@
+//! Architecture specific bits.  Mostly interfaces to specific
+//! machine registers or instructions that must be accessed from
+//! assembler.
+
+use crate::dat::{Flags, Gdt, Idt};
+
+use bit_field::BitField;
+use core::arch::asm;
+
+/// Retrieves a copy of the `RFLAGS` registers.
+pub(crate) fn flags() -> Flags {
+    const MB1: u64 = 0b10;
+    unsafe {
+        let raw: u64;
+        asm!("pushfq; popq {};", out(reg) raw, options(att_syntax));
+        Flags::new(raw | MB1)
+    }
+}
+
+pub(crate) fn fmask() -> u64 {
+    Flags::empty().with_intr(true).with_trap(true).with_dir(true).bits()
+}
+
+/// Executes the `STI` instruction that enables interrupt
+/// delivery on the current CPU, by setting the "Interrupt
+/// Enable" bit (`IF`) in the `RFLAGS` register
+pub(crate) fn sti() {
+    unsafe {
+        asm!("sti");
+    }
+}
+
+/// Executes the `CLI` instruction that disables interrupt
+/// delivery on the current CPU, by clearing the "Interrupt
+/// Enable" bit (`IF`) in the `RFLAGS` register
+pub(crate) fn cli() {
+    unsafe {
+        asm!("cli");
+    }
+}
+
+/// Loads the "Task Register" (`TR`) with the given 16-bit
+/// selector index, which identifies a "Task State Selector"
+/// (that points to a "Task State Segment" [TSS]) in the Global
+/// Descriptor Table (GDT).
+///
+/// # Safety
+/// The given selector must identify a well-formed TSS selector
+/// in the presently loaded GDT.
+pub(crate) unsafe fn ltr(selector: u16) {
+    unsafe {
+        asm!("ltr {:x};", in(reg) selector);
+    }
+}
+
+/// Loads the "Global Table Descriptor Register" (`GDTR`) with
+/// the base address and inclusive limit inclusive of a "Global
+/// Descriptor Table" (GDT).
+///
+/// # Safety
+/// The referred GDT must be architecturally valid.
+pub(crate) unsafe fn lgdt(gdt: &Gdt) {
+    let ptr: *const Gdt = gdt;
+    unsafe {
+        asm!(r#"
+            subq $16, %rsp;
+            movq {base}, 8(%rsp);
+            movw ${limit}, 6(%rsp)
+            lgdt 6(%rsp);
+            movq $8, 8(%rsp);
+            lea 1f(%rip), %rax;
+            movq %rax, (%rsp);
+            lretq;
+            1:
+            "#,
+            base = in(reg) u64::try_from(ptr.addr()).unwrap(),
+            limit = const core::mem::size_of::<Gdt>().wrapping_sub(1) as u16,
+            options(att_syntax)
+        );
+    }
+}
+
+/// Loads the "Interrupt Descriptor Table Register" (`IDTR`)
+/// with the base address and inclusive limit of an "Interrupt
+/// Descriptor Table" (IDT).
+///
+/// # Safety
+/// The referred IDT must be architecturally valid.
+pub(crate) unsafe fn lidt(idt: &Idt) {
+    let ptr: *const Idt = idt;
+    unsafe {
+        asm!(r#"
+            subq $16, %rsp;
+            movq {base}, 8(%rsp);
+            movw ${limit}, 6(%rsp)
+            lidt 6(%rsp);
+            addq $16, %rsp;
+            "#,
+            base = in(reg) u64::try_from(ptr.addr()).unwrap(),
+            limit = const core::mem::size_of::<Idt>().wrapping_sub(1) as u16,
+            options(att_syntax)
+        );
+    }
+}
+
+/// Reads an MSR
+///
+/// # Safety
+/// The caller must ensure that the MSR is valid.
+pub unsafe fn _rdmsr(msr: u32) -> u64 {
+    let lo: u32;
+    let hi: u32;
+    unsafe {
+        asm!("rdmsr",
+            in("ecx") msr,
+            out("eax") lo,
+            out("edx") hi,
+            options(att_syntax));
+    }
+    u64::from(hi) << 32 | u64::from(lo)
+}
+
+/// Writes an MSR
+///
+/// # Safety
+/// The caller must ensure that the value and MSR are
+/// valid, and that the value makes sense for the MSR.
+pub(crate) unsafe fn wrmsr(msr: u32, value: u64) {
+    unsafe {
+        asm!("wrmsr",
+            in("ecx") msr,
+            in("eax") value.get_bits(0..32),
+            in("edx") value.get_bits(32..64),
+            options(att_syntax));
+    }
+}
+
+/// Writes the GS Base register.
+///
+/// # Safety
+/// The caller must ensure that the given value makes sense as
+/// a %gs segment base value.
+pub(crate) unsafe fn wrgsbase(value: u64) {
+    unsafe {
+        asm!("wrgsbase {}", in(reg) value, options(att_syntax));
+    }
+}

--- a/x86_64/src/dat.rs
+++ b/x86_64/src/dat.rs
@@ -1,1 +1,303 @@
-//
+pub use crate::vsvm::{Gdt, Idt, Tss};
+
+use bitstruct::bitstruct;
+use port::dat as portdat;
+use zerocopy::FromZeros;
+
+pub const UREG_TRAPNO_OFFSET: usize = 19 * core::mem::size_of::<u64>();
+pub const UREG_CS_OFFSET: usize = 22 * core::mem::size_of::<u64>();
+
+/// The user register and trap frame structure.
+///
+/// This stores both user state during system calls, and
+/// and trap frames for any kind of interrupt, exception,
+/// or fault.
+///
+/// Warning: The format of this structure is (necessarily)
+/// known to assembly language.  Caveat emptor.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct Ureg {
+    // Pushed by software.
+    ax: u64,
+    bx: u64,
+    cx: u64,
+    dx: u64,
+    si: u64,
+    di: u64,
+    bp: u64,
+    r8: u64,
+    r9: u64,
+    r10: u64,
+    r11: u64,
+    r12: u64,
+    r13: u64,
+    r14: u64,
+    r15: u64,
+
+    // It is arguable whether we should care about
+    // these registers.  x86 segmentation (aside from
+    // FS and GS) isn't used once we're in long mode,
+    // and r9 doesn't support real or compatibility
+    // mode, so these are effectively unused.
+    //
+    // Regardless, they exist, so we save and restore
+    // them.  Some kernels do this, some do not.  Note
+    // that %fs and %gs are special.
+    ds: u64, // Really these are u16s, but
+    es: u64, // we waste a few bytes to keep
+    fs: u64, // the stack aligned.  Thank
+    gs: u64, // you, x86 segmentation.
+
+    trapno: u64,
+
+    // Sometimes pushed by hardware.
+    pub ecode: u64,
+
+    // Pushed by hardware.
+    pub pc: u64,
+    cs: u64,
+    flags: u64,
+    sp: u64,
+    ss: u64,
+}
+
+#[derive(Clone, Debug, FromZeros)]
+#[repr(C)]
+pub struct Label {
+    pub pc: u64,
+    pub sp: u64,
+    pub fp: u64,
+    rbx: u64,
+    r12: u64,
+    r13: u64,
+    r14: u64,
+    r15: u64,
+}
+
+impl Label {
+    pub const fn new() -> Label {
+        Label { pc: 0, sp: 0, fp: 0, rbx: 0, r12: 0, r13: 0, r14: 0, r15: 0 }
+    }
+}
+
+impl Default for Label {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The machine structure, which describes a CPU.
+///
+/// Warning: the layout of this structure is known to assembly
+/// language.
+#[derive(FromZeros)]
+#[repr(C, align(65536))]
+pub struct Mach {
+    me: *mut Mach,            // %gs:0 is a `*mut Mach` pointing to this `Mach`.
+    scratch: usize,           // A scratch word used on entry to kernel
+    splpc: usize,             // PC of last caller to ` k`.  Cleared by `spllo`.
+    proc: *mut portdat::Proc, // Current process on this process.
+
+    machno: u32,  // Logical ID of CPU.
+    cpuno: u32,   // Physical ID of CPU.
+    online: bool, // Is this CPU online?
+    cpuhz: u64,
+
+    // Various stats that the kernel keeps track of
+    ticks: u64,
+    tlbfaults: u64,
+    ulbpurges: u64,
+    pfaults: u64,
+    syscalls: u64,
+    mmuflushes: u64,
+
+    sched: Label,
+
+    // Architecturally defined.
+    pub tss: Tss,
+
+    // All preceding data fits within a single 4KiB page.  Structures
+    // that follow are sized in page multiples and aligned.
+    pml4: Page,               // PML4 root page table for this Mach
+    pml3: Page,               // The PML3 that maps the kernel for this mach
+    pml2: Page,               // PML2 for low 1GiB
+    pml1: Page,               // PML1 for low 2MiB
+    pub idt: Idt,             // Interrupt descriptor table
+    zero: Page,               // Read-only, zeroed page
+    pub df_stack: ExStack,    // Stack for double faults
+    pub debug_stack: ExStack, // Stack for debug exceptions
+    pub nmi_stack: ExStack,   // Stack for NMIs
+    pub stack: KStack,        // Kernel stack for scheduler
+    pub gdt: Gdt,             // Gdt is aligned to 64KiB.
+}
+static_assertions::const_assert_eq!(core::mem::offset_of!(Mach, pml4), 4096);
+static_assertions::const_assert_eq!(core::mem::offset_of!(Mach, stack), 65536);
+
+impl Mach {
+    pub unsafe fn init(&mut self) {
+        use crate::trap;
+        self.me = self;
+        self.tss.init(&mut [
+            (0, &mut self.stack),
+            (trap::NMI_TRAPNO, &mut self.nmi_stack),
+            (trap::DEBUG_TRAPNO, &mut self.debug_stack),
+            (trap::DOUBLE_FAULT_TRAPNO, &mut self.df_stack),
+        ]);
+        self.gdt.init(&self.tss);
+        self.idt.init(trap::stubs());
+        unsafe {
+            self.gdt.load();
+            self.idt.load();
+            self.tss.load();
+        }
+    }
+}
+
+#[repr(u8)]
+pub enum MachMode {
+    Kernel,
+    Ring1,
+    Ring2,
+    User,
+}
+
+impl From<u8> for MachMode {
+    fn from(raw: u8) -> Self {
+        match raw {
+            0b00 => MachMode::Kernel,
+            0b01 => MachMode::Ring1,
+            0b10 => MachMode::Ring2,
+            0b11 => MachMode::User,
+            _ => panic!("invalid machine mode: {raw:x}"),
+        }
+    }
+}
+
+impl From<MachMode> for u8 {
+    fn from(mode: MachMode) -> u8 {
+        match mode {
+            MachMode::Kernel => 0b00,
+            MachMode::Ring1 => 0b01,
+            MachMode::Ring2 => 0b10,
+            MachMode::User => 0b11,
+        }
+    }
+}
+
+bitstruct! {
+    #[derive(Clone, Copy, Debug)]
+    #[repr(transparent)]
+    pub struct Flags(u64) {
+        pub carry: bool = 0;
+        mb1: bool = 1;
+        pub parity: bool = 2;
+        pub aux_carry: bool = 4;
+        pub zero: bool = 6;
+        pub sign: bool = 7;
+        pub trap: bool = 8;
+        pub intr: bool = 9;
+        pub dir: bool = 10;
+        pub overflow: bool = 11;
+        pub iopl: MachMode = 12..=13;
+        pub nestedt: bool = 14;
+        pub resume: bool = 16;
+        pub virt8086: bool = 17;
+        pub access: bool = 18;
+        pub virt_intr: bool = 19;
+        pub virt_intr_pending: bool = 20;
+        pub id_flag: bool = 21;
+    }
+}
+
+impl Flags {
+    pub fn empty() -> Self {
+        Self(0)
+    }
+
+    pub fn new(raw: u64) -> Self {
+        Self(raw).with_mb1(true)
+    }
+
+    pub fn bits(self) -> u64 {
+        self.0
+    }
+}
+
+/// The smallest basic page type.
+#[derive(FromZeros)]
+#[repr(C, align(4096))]
+pub struct Page([u8; 4096]);
+
+impl Page {
+    pub const fn empty() -> Page {
+        Page([0; 4096])
+    }
+
+    pub const fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
+
+    pub const fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.0.as_mut_ptr()
+    }
+
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl Default for Page {
+    fn default() -> Page {
+        Page::empty()
+    }
+}
+
+/// A trait for retrieving the top of various kinds of stacks.
+pub trait Stack {
+    fn len(&self) -> usize;
+    fn top(&self) -> *const u8;
+    fn top_mut(&mut self) -> *mut u8;
+}
+
+/// A small stack that we can use for exception handlers
+/// that require their own stack (NMI, Debug, and Double
+/// Fault).
+#[derive(FromZeros)]
+#[repr(C, align(8192))]
+pub struct ExStack(Page);
+
+impl Stack for ExStack {
+    fn top_mut(&mut self) -> *mut u8 {
+        self.0.as_mut_ptr().wrapping_add(self.0.len())
+    }
+
+    fn top(&self) -> *const u8 {
+        self.0.as_ptr().wrapping_add(self.0.len())
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// A kernel stack for a proc.
+#[derive(FromZeros)]
+#[repr(C, align(65536))]
+pub struct KStack([Page; 16]);
+
+impl Stack for KStack {
+    fn top_mut(&mut self) -> *mut u8 {
+        let lastpage = &mut self.0[self.0.len() - 1];
+        lastpage.as_mut_ptr().wrapping_add(lastpage.len())
+    }
+
+    fn top(&self) -> *const u8 {
+        let lastpage = &self.0[self.0.len() - 1];
+        lastpage.as_ptr().wrapping_add(lastpage.len())
+    }
+
+    fn len(&self) -> usize {
+        self.0.len() * self.0[0].len()
+    }
+}

--- a/x86_64/src/l.S
+++ b/x86_64/src/l.S
@@ -1,13 +1,8 @@
+// Position independent code for early boot.
+//
 // It gets ugly to try to link this at some low address
 // and then have the rest of the kernel linked high; that
 // goes doubly for any attempt to load at a random address.
-//
-// So you have to learn to write position independent
-// code here.
-//
-// It will make you stronger.
-//
-// Assuming you survive the training.
 
 // Useful definitions.
 .set GdtNULL,			(0<<3)
@@ -34,14 +29,21 @@
 .set MULTIBOOT_FLAGS,		(MULTIBOOT_FLAG_PGALIGN | MULTIBOOT_FLAG_MEMINFO)
 .set MULTIBOOT_CHECKSUM,	-(MULTIBOOT_MAGIC + MULTIBOOT_FLAGS)
 
-.set PTSZ,			4096
-.set PGSZ,			4096
-.set MACHSTKSZ,			(8*PGSZ)
-
-.set KZERO,			0xffff800000000000
+.set KiB,			(1<<10)
 .set MiB,			(1<<20)
-.set KSYS,			(KZERO+MiB+PGSZ)
-.set KTZERO,			(KZERO+2*MiB)
+.set GiB,			(1<<30)
+
+.set PGSZ,			(4*KiB)
+
+.set KZERO,			0xffffffff80000000
+.set KCPUZERO,			0xffffff0000000000
+.set KMACH,			(1*MiB)
+.set KTOFF,			(2*MiB)
+
+.set MACHSTKSZ,			(16*PGSZ)
+.set MACHSTKOFF,		(16*PGSZ)
+.set MACHGDTSZ,			(16*PGSZ)
+.set MACHGDTOFF,		(32*PGSZ)
 
 .set Cr0PE,			(1<<0)		// Protected Mode Enable
 .set Cr0MP,			(1<<1)		// Monitor Coprocessor
@@ -64,182 +66,168 @@
 .set PteP,			(1<<0)		// Present
 .set PteRW,			(1<<1)		// Read/Write
 .set PtePS,			(1<<7)		// Page Size
+.set PteHiNX,			(1<<31)		// NX in the bit 4 bytes of PTE
 
-.align 4
-.section .boottext, "awx"
-multiboot_header:
-.long MULTIBOOT_MAGIC
-.long MULTIBOOT_FLAGS
-.long MULTIBOOT_CHECKSUM
+.set I8259A0,			0x20
+.set I8259A1,			0xA0
 
 // When we get here we are in protected mode with a GDT.  We set
-// up IA32e mode and get into long mode with paging enabled.
+// up IA32e mode and get into long mode with paging enabled, then
+// jump to Rust.
+//
+// This code is thus responsible for setting up the parts of the
+// Mach required to get us into Rust code, running against our linked
+// addresses.  This means setting up the parts of the Mach required
+// for initial entry into Rust code, and in particular hand-crafting
+// the initial page tables for early boot (the space for which are
+// in the Mach).
+//
+// The initial page tables provide an (nearly) identity mapping for the first
+// 0-4GiB of physical address space to
+// KZERO, in addition to an identity map
+// for the switch from protected to paged mode.  There
+// is an assumption here that the creation and later
+// removal of the identity map will not interfere with
+// the KZERO mappings.
+//
+// The bulk of Mach[0] initialization, including remapping the
+// kernel and setting up most of the architecturally required
+// state, happens in Rust code.  We just do page tables and set
+// up the stack here.
+//
+// Note that this code relies on details of the layout of the
+// Mach.
+.balign 4096
+.section .text.boot, "ax"
+
 .code32
-.align 4
 .globl start
 start:
+	jmp	1f	// Jump over the multiboot header
+	// Multiboot 1 header.
+	.balign 8
+	.long	MULTIBOOT_MAGIC
+	.long	MULTIBOOT_FLAGS
+	.long	MULTIBOOT_CHECKSUM
+	.balign 16
+1:
 	cli
 	cld
 
-	// Save the multiboot magic number.
-	movl	%eax, %ebp
+	// Save the multiboot information pointer.
+	movl	%ebx, %ebp
 
-	// Make the basic page tables for CPU0 to map 0-4GiB
-	// physical to KZERO, in addition to an identity map
-	// for the switch from protected to paged mode.  There
-	// is an assumption here that the creation and later
-	// removal of the identity map will not interfere with
-	// the KZERO mappings.
+	// Mask off the PIC.  We never use it.
+	movw	$(I8259A0 + 1), %dx
+	movb	$0xFF, %al
+	outb	%al, %dx
+	movw	$(I8259A1 + 1), %dx
+	outb	%al, %dx
+
+	// Zero the second mibibyte of RAM.  This region holds
+	// the Mach for core 0, which in turn holds space for the
+	// various architecturally defined state required for
+	// handling traps and syscalls, switching processes, and
+	// so on.
 	//
-	// We assume a recent processor with Page Size Extensions
-	// and use two 2MiB entries.
-
-	// Zero the stack, page tables, vsvm, unused pages, m, sys, etc.
-	movl	$(KSYS-KZERO), %esi
-	movl	$((KTZERO-KSYS)/4), %ecx
+	// We could also zero the BSS here, but the loader does it
+	// for us.
+	movl	$KMACH, %edi
+	movl	$(KTOFF-KMACH), %ecx
 	xorl	%eax, %eax
-	movl	%esi, %edi
-	rep stosl
+	rep stosb
 
-	// We could zero the BSS here, but the loader does it for us.
+	// Load the physical address of the Mach into the base register
+	movl	$KMACH, %ebx
 
-	// Set the stack and find the start of the page tables.
-	movl	%esi, %eax
-	addl	$MACHSTKSZ, %eax
-	movl	%eax, %esp			// Give ourselves a stack
+	// Load the stack pointer
+	leal	MACHSTKOFF+MACHSTKSZ(%ebx), %esp
 
-	// %eax points to the PML4 that we'll use for double-mapping
-	// low RAM and KZERO.
-	movl	%eax, %cr3			// load the MMU; paging still disabled
-	movl	%eax, %edx
-	addl	$(2*PTSZ|PteRW|PteP), %edx	// EPML3 at IPML4 + 2*PTSZ
-	movl	%edx, (%eax)			// IPML4E for identity map
-	movl	%edx, 2048(%eax)		// IPML4E for KZERO
+	// The PML4 we ordinarily run on lives inside of the Mach.
+	// However, we'd much rather set it up in Rust code, not here,
+	// so we use a set of simple, hard-coded page tables early on
+	// in boot.  These place the Mach at the expected location, so
+	// that we can refer to our stack at the correct virtual address
+	// space, but do not handle anything beyond the bare minimum.
+	movl	$(bootpml4 - KZERO), %eax
+	movl	%eax, %cr3
 
-	// The next page frame contains a PML4 that removes the double
-	// mapping, leaving only KZERO mapped.
-	addl	$PTSZ, %eax			// EPML4 at IPML4 + PTSZ
-	movl	%edx, 2048(%eax)		// EPML4E for EMPL3 at KZERO
-
-	// Fill in the early PML3 (PDPT) to point the early PML2's (PDs)
-	// that provide the initial 4GiB mapping in the kernel.
-	addl	$PTSZ, %eax			// EPML3 at EPML4 + PTSZ
-	addl	$PTSZ, %edx			// EPML2[0] at EPML3 + PTSZ
-	movl	%edx, (%eax)			// EPML3E for EPML2[0]
-	addl	$PTSZ, %edx			// EPML2[1] at EPML2[0] + PTSZ
-	movl	%edx, 8(%eax)			// EPML3E for EPML2[1]
-	addl	$PTSZ, %edx			// EPML2[2] at EPML2[1] + PTSZ
-	movl	%edx, 16(%eax)			// EPML3E for EPML2[2]
-	addl	$PTSZ, %edx			// EPML2[3] at EPML2[2] + PTSZ
-	movl	%edx, 24(%eax)			// EPML3E for EPML2[3]
-
-	// Map the first 4GiB (the entire 32-bit) address space.
-	// Note that this requires 16KiB.
-	//
-	// The first 2MiB are mapped using 4KiB pages.  The first 1MiB
-	// memory contains holes for MMIO and ROM and other things that
-	// we want special attributes for.  We'll set those in the
-	// kernel proper, but we provide 4KiB pages here.  There is 4KiB
-	// of RAM for the PT immediately after the PDs.
-	addl	$PTSZ, %eax			// PML2[0] at PML3[0] + PTSZ
-	movl	$2048, %ecx			// 2048 * 2MiB pages covers 4GiB
-	movl	$(PtePS|PteRW|PteP), %edx	// Large page PDEs
-1:	movl	%edx, (%eax)			// PDE for 2MiB pages
-	addl	$8, %eax
-	addl	$(2<<20), %edx
-	subl	$1, %ecx
-	test	%ecx, %ecx
-	jnz	1b
-
-	// %eax now points to the page after the EPML2s, which is the real
-	// self-referential PML4.
-	// Map the first 192 entries for the upper portion of the address
-	// space to PML3s; this is the primordial root of sharing for the
-	// kernel.
-	movl	%eax, %edx
-	addl	$(PTSZ|PteRW|PteP), %edx	// PML3[0] at PML4 + PTSZ
-	movl	$256, %ecx
-1:	movl	%edx, (%eax, %ecx, 8)
-	addl	$PTSZ, %edx
-	incl	%ecx
-	cmp	$(256+192), %ecx
-	jne	1b
-
-	// Enable and activate Long Mode.  From the manual:
-	// make sure Page Size Extentions are off, and Page Global
-	// Extensions and Physical Address Extensions are on in CR4;
-	// set Long Mode Enable in the Extended Feature Enable MSR;
-	// set Paging Enable in CR0;
-	// make an inter-segment jump to the Long Mode code.
-	// It`s all in 32-bit mode until the jump is made.
+	// Enable global pages and the physical address extension.  Turn
+	// off the page size extension; it is always eanbled in PAE mode.
 	movl	%cr4, %eax
-	andl	$~Cr4PSE, %eax			// Page Size
-	orl	$(Cr4PGE|Cr4PAE), %eax		// Page Global, Phys. Address
+	andl	$~Cr4PSE, %eax
+	orl	$(Cr4PGE|Cr4PAE), %eax
 	movl	%eax, %cr4
 
-	movl	$IA32_EFER, %ecx		// Extended Feature Enable
+	// Set up the Extended Feature Enable (EFER) MSR, enabling
+	// long mode, the NX bit in PTEs, and the SYSCALL/SYSRET
+	// instructions.
+	movl	$IA32_EFER, %ecx	// Extended Feature Enable
 	rdmsr
-	// Enable long mode, NX bit in PTEs and SYSCALL/SYSREG.
 	orl	$(EferSCE|EferLME|EferNXE), %eax
 	wrmsr
 
-	movl	%cr0, %edx
-	andl	$~(Cr0CD|Cr0NW|Cr0TS|Cr0MP), %edx
-	orl	$(Cr0PG|Cr0WP), %edx		// Paging Enable
-	movl	%edx, %cr0
+	// Enable caching, paging, and page permisson enforcement in
+	// kernel mode.
+	movl	%cr0, %eax
+	andl	$~(Cr0CD|Cr0NW|Cr0TS|Cr0MP), %eax
+	orl	$(Cr0PG|Cr0WP), %eax
+	movl	%eax, %cr0
 
 	// Load the 64-bit GDT
 	movl	$(gdtdesc-KZERO), %eax
 	lgdt	(%eax)
 
+	// Jump into 64 bit code.
 	ljmpl	$GdtCODE64, $(1f-KZERO)
 
 .code64
 1:
-	// Long mode. Welcome to 2003.  Jump out of the identity map
-	// and into the kernel address space.
+	// Long mode.  Welcome to 2003.  Reload the GDT at its linked
+	// linear address, and jump out of the identity map and into
+	// the kernel address space.
 
 	// Load a 64-bit GDT in the kernel address space.
 	movabsq	$gdtdescv, %rax
 	lgdt	(%rax)
-
+	pushq	$GdtCODE64
+	pushq	$(1f-KZERO)
+	lretq
+1:
 	// Zero out the segment registers: they are not used in long mode.
-	xorl	%edx, %edx
-	movw	%dx, %ds
-	movw	%dx, %es
-	movw	%dx, %fs
-	movw	%dx, %gs
-	movw	%dx, %ss
+	xorl	%eax, %eax
+	movw	%ax, %ds
+	movw	%ax, %es
+	movw	%ax, %ss
+	movw	%ax, %fs
+	movw	%ax, %gs
 
 	// We can now use linked addresses for the stack and code.
 	// We'll jump into the kernel from here.
-	movabsq	$KZERO, %rax
-	addq	%rax, %rsp
+	movabsq	$(KCPUZERO+KMACH), %rdi
+	leaq	MACHSTKOFF+MACHSTKSZ(%rdi), %rsp
 	movabsq	$warp64, %rax
-	jmp	*%rax
+	pushq	%rax
+	ret
 
-.text
-.code64
 warp64:
 	// At this point, we are fully in the kernel virtual
-	// address space and we can discard the identity mapping.
-	// There is a PML4 sans identity map 4KiB beyond the
-	// current PML4; load that, which also flushes the TLB.
-	movq	%cr3, %rax
-	addq	$PTSZ, %rax
+	// address space and can discard the identity mapping.
+	// To do so, we load the early PML4 that does not have
+	// that entry.
+	movq	$(earlypml4 - KZERO), %rax
 	movq	%rax, %cr3			// Also flushes TLB.
 
-	// &sys->mach is the first argument to main()
-	movabsq	$KSYS, %rdi
-	addq	$(MACHSTKSZ+(1+1+1+4+1+192)*PTSZ+PGSZ), %rdi
-	movq	%rbp, %rsi			// multiboot magic
-	movq	%rbx, %rdx			// multiboot info pointer
+	// A pointer to the Mach is already in %rdi, and is the
+	// first argument to `main`.  We also pass the multiboot info
+	// pointer.
+	movq	%rbp, %rsi
 
 	// Push a dummy stack frame and jump to `main`.
 	pushq	$0
-	movq	$0, %rbp
-	leaq	main9(%rip), %rax
-	push	%rax
+	xorl	%ebp, %ebp
+	leaq	main(%rip), %rax
+	pushq	%rax
 	pushq	$2				// clear flags
 	popfq
 	ret
@@ -247,33 +235,48 @@ warp64:
 
 // no deposit, no return
 // do not resuscitate
+.text
+.code64
 .globl ndnr
 ndnr:
-	sti
+	cli
 	hlt
 	jmp	ndnr
 
-// Start-up request IPI handler.
+// Start-up IPI handler.
 //
 // This code is executed on an application processor in response
 // to receiving a Start-up IPI (SIPI) from another processor.  The
 // vector given in the SIPI determines the memory address the
 // where the AP starts execution.
 //
-// The AP starts in real-mode, with
-//   CS selector set to the startup memory address/16;
-//   CS base set to startup memory address;
-//   CS limit set to 64KiB;
-//   CPL and IP set to 0.
+// The AP starts in 16-bit real-mode, with:
+//  - CS selector set to the startup memory address/16;
+//  - CS base set to startup memory address;
+//  - CS limit set to 64KiB;
+//  - IP set to 0;
+//  - CPL set to 0;
+//  - A20 latch disabled.
+// Welcome to 1978.
 //
-// This must be placed on a 4KiB boundary, and while it may seem
-// like this should be in a text section, it is deliberately not.
-// The AP entry code is copied to a page in low memory at APENTRY
-// for execution, so as far as the rest of the kernel is concerned
-// it is simply read-only data.  We put it into .rodata so that it
-// is mapped onto a non-executable page and the kernel cannot
-// accidentally jump into it once it is running in C code on a
-// real page table.
+// The startup memory address is calculated as the vector given in
+// the SIPI request, left-shited 12 bits.  Thus, this code must be
+// placed on a 4KiB boundary somewhere in low 1 MiB of memory.  We
+// have arbitrarily chosen 0x7000, denoted by the symbol `APENTRY`.
+//
+// While it may seem like this should be in a text section, it is
+// deliberately not.  Since this code is copied to APENTRY
+// for execution, so as far as the rest of the kernel is concerned,
+// the assembled and linked instructions here are just read-only
+// data.  So, we put it into .rodata so that it is mapped onto a
+// non-executable page and the kernel cannot accidentally jump
+// into it once it is running in Rust code on a real page table.
+//
+// Note that the physical address of the PML4 in the `Mach` for
+// this AP is copied into the last 8 bytes of the AP startup page.
+// We can use this to establish set the virtual address space for
+// this CPU, once we're in long mode.  We use the space immediately
+// below that word as a very small stack for getting into long mode.
 //
 // The 16-bit code loads a basic GDT, turns on 32-bit protected
 // mode and makes an inter-segment jump to the protected mode code
@@ -283,14 +286,14 @@ ndnr:
 // jumps to 64-bit mode, which fixes up virtual addresses for
 // the stack and PC and jumps into C.
 
-.set APENTRY,		0x3000
-.set APPERCPU,		(0x4000-8)
+.set APENTRY,		(7*PGSZ)
+.set APMACH,		(APENTRY+PGSZ-8)
 
 .section .rodata
 
 .globl b1978, e1978
+.balign 4096
 .code16
-.align 4096
 b1978:
 	// We start here in real mode.  Welcome to 1978.
 	cli
@@ -304,7 +307,7 @@ b1978:
 
 	ljmpl   $GdtCODE32, $(b1982-KZERO)
 
-.align 16
+.balign 16
 gdt:
 	// 0: Null segment
 	.quad	0
@@ -316,57 +319,75 @@ gdt:
 	.quad	(SegREAD|SegWRITE|SegMB1|SegPRESENT|Seg32DEF)
 egdt:
 
+.balign 16
+.skip 6
+gdtdesc:
+	.word	egdt - gdt - 1
+	.long	(gdt - KZERO)
+
+.balign 16
+.skip 6
+gdtdescv:
+	.word	egdt - gdt - 1
+	.quad	gdt
+
 .skip 6
 apgdtdesc:
 .word	egdt - gdt - 1
 .long	(APENTRY+gdt-b1978)
 
-e1978:
-
-.text
 .code32
 b1982:
 	// Protected mode. Welcome to 1982.
 	movw	$GdtDATA32, %ax
 	movw	%ax, %ds
 	movw	%ax, %es
-	movw	%ax, %fs
-	movw	%ax, %gs
 	movw	%ax, %ss
 
-	// load the PML4 with the shared page table address;
-	// make an identity map for the inter-segment jump below,
-	// using the stack space to hold a temporary PDP and PD;
-	// enable and activate long mode;
-	// make an inter-segment jump to the long mode code.
-	movl	$(KSYS-KZERO+MACHSTKSZ), %eax	// Page table
-	movl	%eax, %cr3			// load the mmu
+	xorl	%eax, %eax
+	movw	%ax, %fs
+	movw	%ax, %gs
+
+	// In order to fully boot, we need page tables to get into the
+	// kernel at its linked addresses, so we reuse the ones used
+	// earlier for booting CPU 0.  But note that these also map
+	// CPU 0's Mach, and we'll need our own Mach.  While the Mach
+	// is mapped at the same virtual address on each CPU, each is
+	// obviously different than CPU 0's, and we don't want to
+	// trample it.
+	//
+	// Fortunately, CPU 0 arranges for the physical address of
+	// the PML4 for this AP to be at the absolute location APMACH,
+	// so we can load our page tables and then set up the pointer
+	// to our own Mach.
+	//
+	// We also use the space below APMACH as a (very) small stack
+	// for the jump to our linked address.
+	movl	$(bootpml4 - KZERO), %eax
+	movl	%eax, %cr3
 
 	// Enable and activate Long Mode.
 	movl	%cr4, %eax
-	andl	$~Cr4PSE, %eax			// Page Size
-	orl	$(Cr4PGE|Cr4PAE), %eax		// Page Global, Phys. Address
+	andl	$~Cr4PSE, %eax		// PSE always true in long mode
+	orl	$(Cr4PGE|Cr4PAE), %eax	// Page Global, Phys. Address Ext
 	movl	%eax, %cr4
 
-	movl	$IA32_EFER, %ecx		// Extended Feature Enable
+	movl	$IA32_EFER, %ecx	// Extended Feature Enable
 	rdmsr
 	orl	$(EferSCE|EferLME|EferNXE), %eax
-	wrmsr					// Long Mode Enable
+	wrmsr				// Long Mode Enable
 
 	movl	%cr0, %edx
 	andl	$~(Cr0CD|Cr0NW|Cr0TS|Cr0MP), %edx
-	orl	$(Cr0PG|Cr0WP), %edx		// Paging Enable
+	orl	$(Cr0PG|Cr0WP), %edx	// Paging Enable
 	movl	%edx, %cr0
 
 	ljmp	$GdtCODE64, $(1f-KZERO)
 
 .code64
 1:
-	movq	APPERCPU, %rdi
-	addq	$MACHSTKSZ, %rdi
-	movq	%rdi, %rsp			// set stack
-	addq	$(PTSZ+PGSZ), %rdi		// Mach *
-
+	leaq	APMACH, %rdi
+	movq	%rdi, %rsp
 	movabsq	$apwarp64, %rax
 	pushq	%rax
 	ret
@@ -375,37 +396,62 @@ b1982:
 apwarp64:
 	movabsq	$gdtdescv, %rax
 	lgdt	(%rax)
+	pushq	$GdtCODE64
+	pushq	$(1f-KZERO)
+	lretq
+1:
 
-	xorl	%edx, %edx
-	movw	%dx, %ds
-	movw	%dx, %es
-	movw	%dx, %fs
-	movw	%dx, %gs
-	movw	%dx, %ss
+	xorl	%eax, %eax
+	movw	%ax, %ds
+	movw	%ax, %es
+	movw	%ax, %fs
+	movw	%ax, %gs
+	movw	%ax, %ss
 
-	movq	%cr3, %rax
-	addq	$(7*PTSZ), %rax
-	movq	%rax, %cr3			// flush TLB
+	// Move to the real PML4 from our Mach.
+	movq	(%rdi), %rax
+	movq	%rax, %cr3
+
+	// Load the address of our Mach as the argument for squidboy,
+	// and load our real stack pointer from the Mach.
+	movabsq	$(KCPUZERO+KMACH), %rdi
+	leaq	MACHSTKOFF+MACHSTKSZ(%rdi), %rsp
 
 	pushq	$0
-	movq	$0, %rbp
-	movq	8(%rdi), %rax			// m->splpc
+	xorl	%ebp, %ebp
+	movq	8(%rdi), %rax			// m->scratch
 	pushq	%rax
 	pushq	$2				// Clear flags
 	popfq
 	ret					// Call squidboy
 	ud2
 
-.section .rodata
+e1978:
 
-.align 16
-.skip 6
-gdtdesc:
-	.word	egdt - gdt - 1
-	.long	(gdt - KZERO)
+.balign 4096
+bootpml4:
+	.quad	bootidentitypt3 - KZERO + (PteRW | PteP)
+	.space	4096 - 3*8
+	.quad	earlymachpt3 - KZERO + (PteRW | PteP)
+	.quad	earlykernpt3 - KZERO + (PteRW | PteP)
 
-.align 16
-.skip 6
-gdtdescv:
-	.word	egdt - gdt - 1
-	.quad	gdt
+earlypml4:
+	.space 4096 - 2*8
+	.quad	earlymachpt3 - KZERO + (PteRW | PteP)
+	.quad	earlykernpt3 - KZERO + (PteRW | PteP)
+
+bootidentitypt3:
+	.quad	(0<<30) + (PtePS | PteRW | PteP)
+	.quad	(1<<30) + (PtePS | PteRW | PteP)
+	.quad	(2<<30) + (PtePS | PteRW | PteP)
+	.quad	(3<<30) + (PtePS | PteRW | PteP)
+	.space	4096 - 4*8
+
+earlymachpt3:
+	.quad	(0<<30) + (PtePS | PteRW | PteP)
+	.space	4096 - 1*8
+
+earlykernpt3:
+	.space	4096 - 2*8
+	.quad	(0<<30) + (PtePS | PteRW | PteP)
+	.quad	0

--- a/x86_64/src/proc.rs
+++ b/x86_64/src/proc.rs
@@ -1,22 +1,5 @@
+pub use crate::dat::Label;
 use core::arch::naked_asm;
-
-#[repr(C)]
-pub struct Label {
-    pub pc: u64,
-    pub sp: u64,
-    pub fp: u64,
-    rbx: u64,
-    r12: u64,
-    r13: u64,
-    r14: u64,
-    r15: u64,
-}
-
-impl Label {
-    pub const fn new() -> Label {
-        Label { pc: 0, sp: 0, fp: 0, rbx: 0, r12: 0, r13: 0, r14: 0, r15: 0 }
-    }
-}
 
 #[unsafe(naked)]
 pub unsafe extern "C" fn swtch(save: &mut Label, next: &mut Label) {

--- a/x86_64/src/syscall.rs
+++ b/x86_64/src/syscall.rs
@@ -1,0 +1,180 @@
+//! Syscall support code.
+
+use crate::cpu;
+use crate::dat;
+use crate::vsvm;
+
+use core::arch::naked_asm;
+
+pub(crate) fn init() {
+    const MSR_STAR: u32 = 0xc000_0081;
+    const MSR_LSTAR: u32 = 0xc000_0082;
+    const MSR_FMASK: u32 = 0xc000_0084;
+    unsafe {
+        cpu::wrmsr(MSR_LSTAR, entry as usize as u64);
+        cpu::wrmsr(MSR_STAR, vsvm::Gdt::star());
+        cpu::wrmsr(MSR_FMASK, cpu::fmask());
+    }
+}
+
+extern "C" fn dispatch(user: &mut dat::Ureg, sysno: u32) -> i64 {
+    crate::println!("Got a system call ({sysno}): {user:#x?}");
+    0
+}
+
+/// This is the system call entry handler, that is invoked by
+/// the execution of the `SYSCALL` instruction.
+///
+/// On entry:
+///  - The user %rip is in %rcx (hardware)
+///  - The user %rflags is in %r11 (hardware)
+///  - System call number is in %rax (software convention)
+///  - Up to 6 system call arguments are passed in %rdi, %rsi,
+///    %rdx, %r10, %r8, and $9, respectively.
+///
+/// None of the other general purpose registers are handled
+/// specially.
+#[unsafe(naked)]
+unsafe extern "C" fn entry() {
+    naked_asm!(
+        r#"
+        // Switch user and kernel GSBASE
+        swapgs
+
+        // Stash the user stack pointer in the Mach's
+        // `scratch` field, and set the kernel stack
+        // pointer.  The kernel stack is known to be
+        // just below the proc.
+        movq	%rsp, %gs:8
+        movq	%gs:24, %rsp
+
+        // We construct a Ureg on the stack, but many of the
+        // fields therein are not used by the system call machinery.
+        // We push dummy values for them anyway.
+        subq    $(26*8), %rsp       // mem::size_of::<dat::Ureg>()
+
+        movq    %rax, 0*8(%rsp)     // ureg.ax  (syscall number)
+        movq    %rbx, 1*8(%rsp)     // ureg.bx
+        movq    %rcx, 2*8(%rsp)     // ureg.cx  (user pc)
+        movq    %rdx, 3*8(%rsp)     // ureg.dx
+        movq    %rsi, 4*8(%rsp)     // ureg.si
+        movq    %rdi, 5*8(%rsp)     // ureg.di
+        movq    %rbp, 6*8(%rsp)     // ureg.bp
+        movq    %r8, 7*8(%rsp)      // ureg.r8
+        movq    %r9, 8*8(%rsp)      // ureg.r9
+        movq    %r10, 9*8(%rsp)     // ureg.r10
+        movq    %r11, 10*8(%rsp)    // ureg.r11 (user flags)
+        movq    %r12, 11*8(%rsp)    // ureg.r12
+        movq    %r13, 12*8(%rsp)    // ureg.r13
+        movq    %r14, 13*8(%rsp)    // ureg.r14
+        movq    %r15, 14*8(%rsp)    // ureg.r15
+        // Save the x86 segmentation registers.  Uses %rdi
+        // as a scratch register, so we do this after we've
+        // saved the GP registers.  Note that the 32-bit
+        // `movl` zero-extends the segmentation register and
+        // clears the upper bits of %rdi.  We use this
+        // because the result has a denser encoding than
+        // other instruction sequences.
+        movl	%ds, %ebx
+        movq	%rbx, 15*8(%rsp)    // ureg.ds
+        movl	%es, %ebx
+        movq	%rbx, 16*8(%rsp)    // ureg.es
+        movl	%fs, %ebx
+        movq	%rbx, 17*8(%rsp)    // ureg.fs
+        // %gs is special due to SWAPGS
+        movq	$0, 18*8(%rsp)      // ureg.gs
+
+        movq    $0, 19*8(%rsp)      // ureg.trapno
+        movq    $0, 20*8(%rsp)      // ureg.ecode
+        movq    %rcx, 21*8(%rsp)    // ureg.pc
+
+        movl	%cs, %ebx
+        movq    %rbx, 22*8(%rsp)    // ureg.cs
+
+        movq    %r11, 23*8(%rsp)    // ureg.flags
+
+        movq    %gs:8, %rbx
+        movq    %rbx, 24*8(%rsp)    // ureg.sp
+        movl    %ss, %ebx
+        movq    %rbx, 25*8(%rsp)    // ureg.ss
+
+        // Set up a call frame so that we can get a back trace
+        // from here, possibly into user code.
+        pushq   ${syscallret}       // We'll return here.
+        pushq   %rcx                // ret is user PC
+        movq    %gs:8, %rbp         // user sp
+
+        // System call number is 4th argument to `syscall` function.
+        movq    %rsp, %rdi          // *mut Ureg is first argument
+        movq    %rax, %rsi          // system call num is second arg
+
+        // Call the handler in Rust.
+        // XXX: Could we `sti` here?
+        callq {syscall}
+
+        // Pop dummy stack frame and jump to syscallret
+        addq    $8, %rsp
+        ret
+        "#,
+        syscall = sym dispatch,
+        syscallret = sym ret,
+        options(att_syntax)
+    );
+}
+
+#[unsafe(naked)]
+pub unsafe extern "C" fn ret() {
+    naked_asm!(
+        r#"
+        // Skip %rax. It is the return value from the system call.
+        addq $8, %rsp
+
+        // %rax is the return value from the system call.
+        movq    1*8(%rsp), %rbx
+        // %rcx is handled specially
+        movq    3*8(%rsp), %rdx
+        movq    4*8(%rsp), %rsi
+        movq    5*8(%rsp), %rdi
+        movq    6*8(%rsp), %rbp
+        movq    7*8(%rsp), %r8
+        movq    8*8(%rsp), %r9
+        movq    9*8(%rsp), %r10
+        movq    10*8(%rsp), %r11
+        movq    11*8(%rsp), %r12
+        movq    12*8(%rsp), %r13
+        movq    13*8(%rsp), %r14
+        movq    14*8(%rsp), %r15
+
+        movq    21*8(%rsp), %rcx    // user PC goes into %rcx
+        movq    23*8(%rsp), %r11    // user FLAGS goes into %r11
+        orq     $2, %r11            // MB1 bit
+
+        // Once we start modifying segmentation and stack registers, we
+        // want to ensure that interrupts are disabled, so that we do not
+        // accidentally take an interrupt on a user stack.
+        cli
+
+        // Restore user segmentation registers.
+        movw    15*8(%rsp), %ds
+        movw    16*8(%rsp), %es
+        movw    17*8(%rsp), %fs
+        // %gs is specially restored by `swapgs`, below.
+
+        // Restore user stack pointer.  Note that this
+        // implicitly deallocates the Ureg; on the next
+        // entry to the kernel, we will reset the stack
+        // pointer to the top of the kstack anyway.  This
+        // implies that the kernel stack for a proc is
+        // empty while that program runs in user mode.
+        movq    24*8(%rsp), %rsp
+        // %ss will be reloaded automatically from STAR.
+
+        // Switch kernel, user GSBASE
+        swapgs
+
+        // Return from system call
+        sysretq
+        "#,
+        options(att_syntax)
+    );
+}

--- a/x86_64/src/trap.rs
+++ b/x86_64/src/trap.rs
@@ -1,0 +1,229 @@
+use crate::cpu;
+use crate::dat::Ureg;
+use crate::dat::{UREG_CS_OFFSET, UREG_TRAPNO_OFFSET};
+
+use core::arch::naked_asm;
+
+pub const DEBUG_TRAPNO: u8 = 1;
+pub const NMI_TRAPNO: u8 = 2;
+pub const DOUBLE_FAULT_TRAPNO: u8 = 8;
+
+type Thunk = unsafe extern "C" fn();
+
+#[repr(transparent)]
+pub struct Stub(usize);
+
+impl Stub {
+    /// Returns a function pointer that represents a stub.
+    pub unsafe fn as_thunk(&self) -> Thunk {
+        unsafe { core::mem::transmute::<usize, Thunk>(self.0) }
+    }
+}
+
+macro_rules! gen_stub {
+    () => {
+        r#".balign 8; pushq $0; callq {intrcommon};"#
+    };
+    (err) => {
+        r#".balign 8; callq {intrcommon};"#
+    };
+}
+
+macro_rules! gen_trap_stub {
+    // These cases include hardware-generated error words
+    // on the trap frame
+    (8) => {
+        gen_stub!(err)
+    };
+    (10) => {
+        gen_stub!(err)
+    };
+    (11) => {
+        gen_stub!(err)
+    };
+    (12) => {
+        gen_stub!(err)
+    };
+    (13) => {
+        gen_stub!(err)
+    };
+    (14) => {
+        gen_stub!(err)
+    };
+    (17) => {
+        gen_stub!(err)
+    };
+    // No hardware error
+    ($num:literal) => {
+        gen_stub!()
+    };
+}
+
+pub fn stubs() -> &'static [Stub; 256] {
+    unsafe { &*(intr_stubs as usize as *const [Stub; 256]) }
+}
+
+/// intr_stubs is just a container for interrupt stubs.  It is
+/// a naked function for convenience.
+///
+/// # Safety
+///
+/// Container for thunks.
+#[unsafe(link_section = ".trap")]
+#[unsafe(naked)]
+#[rustc_align(4096)]
+pub unsafe extern "C" fn intr_stubs() -> ! {
+    use seq_macro::seq;
+    naked_asm!(
+        seq!(N in 0..=255 {
+            concat!( #( gen_trap_stub!(N), )* )
+        }),
+        intrcommon = sym intrcommon, options(att_syntax))
+}
+
+/// intrcommon builds up a Ureg structure at the top of the
+/// current proc's kernel stack.
+///
+/// # Safety
+///
+/// Common trap handler.  Called from interrupt/exception stub.
+#[unsafe(link_section = ".trap")]
+#[unsafe(naked)]
+pub unsafe extern "C" fn intrcommon() -> ! {
+    naked_asm!(r#"
+        // Allocate space to save registers.
+        subq $((4 + 15) * 8), %rsp
+        // Save the general purpose registers.
+        movq %r15, 14*8(%rsp);
+        movq %r14, 13*8(%rsp);
+        movq %r13, 12*8(%rsp);
+        movq %r12, 11*8(%rsp);
+        movq %r11, 10*8(%rsp);
+        movq %r10, 9*8(%rsp);
+        movq %r9, 8*8(%rsp);
+        movq %r8, 7*8(%rsp);
+        movq %rbp, 6*8(%rsp);
+        movq %rdi, 5*8(%rsp);
+        movq %rsi, 4*8(%rsp);
+        movq %rdx, 3*8(%rsp);
+        movq %rcx, 2*8(%rsp);
+        movq %rbx, 1*8(%rsp);
+        movq %rax, 0*8(%rsp);
+        // Save the x86 segmentation registers.  Uses %rdi
+        // as a scratch register, so we do this after we've
+        // saved the GP registers..  Note that the 32-bit
+        // `movl` zero-extends the segmentation register and
+        // clears the upper bits of %rdi.  We use this
+        // because the result has a denser encoding than
+        // other instruction sequences.
+        movl %gs, %edi;
+        movq %rdi, 18*8(%rsp);
+        movl %fs, %edi;
+        movq %rdi, 17*8(%rsp);
+        movl %es, %edi;
+        movq %rdi, 16*8(%rsp);
+        movl %ds, %edi;
+        movq %rdi, 15*8(%rsp);
+        // Fix up the trap number.  We got here via a CALL,
+        // so hardware pushed the address after the CALLQ
+        // instruction onto the stack.  But we know that
+        // each stub is aligned to an 8-byte boundary, at
+        // some offset based on the vector number relative
+        // to the 4096-byte aligned start of the trap stub
+        // array.  Further, each stub is shorter than 8
+        // bytes in length.  Thus, we can compute the
+        // vector number by dividing the return address by
+        // 8, masking off the high bits, and storing it back
+        // into the save area.
+        //
+        // The vector number is an argument to the trap
+        // function, along with the address of the Ureg
+        // we have built at the top of the stack.
+        shrw $3, {trapno_offset}(%rsp);
+        movzbl {trapno_offset}(%rsp), %edi;
+        movq %rdi, {trapno_offset}(%rsp);
+        movq %rsp, %rsi;
+        // If we're already in kernel mode, don't swap %gs.
+        cmpq ${ktext_sel}, {cs_offset}(%rsp);
+        je 1f;
+        swapgs;
+        1:
+        callq {trap};
+        // If we're returning to kernel mode, don't swap %gs.
+        cmpq ${ktext_sel}, {cs_offset}(%rsp);
+        je 1f;
+        swapgs;
+        1:
+        // Restore the general purpose registers.
+        movq 0*8(%rsp), %rax;
+        movq 1*8(%rsp), %rbx;
+        movq 2*8(%rsp), %rcx;
+        movq 3*8(%rsp), %rdx;
+        movq 4*8(%rsp), %rsi;
+        movq 5*8(%rsp), %rdi;
+        movq 6*8(%rsp), %rbp;
+        movq 7*8(%rsp), %r8;
+        movq 8*8(%rsp), %r9;
+        movq 9*8(%rsp), %r10;
+        movq 10*8(%rsp), %r11;
+        movq 11*8(%rsp), %r12;
+        movq 12*8(%rsp), %r13;
+        movq 13*8(%rsp), %r14;
+        movq 14*8(%rsp), %r15;
+        // Restore the segmentation registers.
+        movw 15*8(%rsp), %ds;
+        movw 16*8(%rsp), %es;
+        // %gs is restored via swapgs above.  The system never changes
+        // it, so we don't bother restoring it here.  %fs is special.
+        // We do save and restore it, for TLS if anyone ever uses green
+        // threads.
+        movw 17*8(%rsp), %fs;
+        // movw 18*8(%rsp), %gs;
+        // Pop registers, alignment word and error.
+        addq $((2 + 4 + 15) * 8), %rsp;
+        // Go back to whence you came.
+        iretq
+        "#,
+        ktext_sel = const 8,
+        cs_offset = const UREG_CS_OFFSET,
+        trapno_offset = const UREG_TRAPNO_OFFSET,
+        trap = sym trap,
+        options(att_syntax))
+}
+
+pub enum IntrStatus {
+    Disabled = 0,
+    Enabled = 1,
+}
+
+#[inline(always)]
+fn intrstatus() -> IntrStatus {
+    let flags = cpu::flags();
+    if flags.intr() { IntrStatus::Enabled } else { IntrStatus::Disabled }
+}
+
+pub fn spllo() -> IntrStatus {
+    let prev_level = intrstatus();
+    cpu::sti();
+    prev_level
+}
+
+pub fn splhi() -> IntrStatus {
+    let prev_level = intrstatus();
+    cpu::cli();
+    prev_level
+}
+
+pub fn splx(x: IntrStatus) -> IntrStatus {
+    match x {
+        IntrStatus::Disabled => splhi(),
+        IntrStatus::Enabled => spllo(),
+    }
+}
+
+extern "C" fn trap(vector: u8, trap_frame: &mut Ureg) -> u32 {
+    crate::println!("trap {vector}");
+    crate::println!("frame: {trap_frame:#x?}");
+    unsafe { core::arch::asm!("cli;hlt;") };
+    0
+}

--- a/x86_64/src/vsvm.rs
+++ b/x86_64/src/vsvm.rs
@@ -1,0 +1,366 @@
+//! "Vestigial Segmented Virtual Memory"
+//!
+//! This module is a bit unfortunate; it's simply a grab-bag of
+//! x86 legacy.  Nominally, all of this ought to go into dat.rs,
+//! but that's already busy enough without polluting it with
+//! this goo.
+
+use crate::cpu;
+use crate::dat;
+use crate::trap;
+use crate::trap::{DEBUG_TRAPNO, DOUBLE_FAULT_TRAPNO, NMI_TRAPNO};
+
+use bit_field::BitField;
+use zerocopy::FromZeros;
+
+pub mod seg {
+    use super::{Gdt, IstIndex, Tss, trap};
+    use crate::dat::MachMode;
+
+    use bit_field::BitField;
+    use bitstruct::bitstruct;
+    use zerocopy::FromZeros;
+
+    bitstruct! {
+        /// Segment Descriptors describe memory segments in the GDT.
+        #[derive(Clone, Copy, Debug, FromZeros)]
+        #[repr(transparent)]
+        pub struct Descr(u64) {
+            reserved0: u32 = 0..32;
+            reserved1: u8 = 32..40;
+            pub accessed: bool = 40;
+            pub readable: bool = 41;
+            pub conforming: bool = 42;
+            code: bool = 43;
+            system: bool = 44;
+            iopl: MachMode = 45..47;
+            pub present: bool = 47;
+            reserved2: u8 = 48..52;
+            available: bool = 52;
+            long: bool = 53;
+            default32: bool = 54;
+            granularity: bool = 55;
+            reserved3: u8 = 56..64;
+        }
+    }
+
+    impl Descr {
+        pub const fn empty() -> Descr {
+            Descr(0)
+        }
+        pub const fn null() -> Descr {
+            Self::empty()
+        }
+        pub fn ktext64() -> Descr {
+            Self::empty()
+                .with_system(true)
+                .with_code(true)
+                .with_readable(true)
+                .with_present(true)
+                .with_conforming(true)
+                .with_long(true)
+                .with_iopl(MachMode::Kernel)
+        }
+        pub fn kdata64() -> Descr {
+            Self::empty()
+                .with_system(true)
+                .with_code(false)
+                .with_readable(true)
+                .with_present(true)
+                .with_long(true)
+                .with_iopl(MachMode::Kernel)
+        }
+        pub fn utext64() -> Descr {
+            Self::empty()
+                .with_system(true)
+                .with_code(true)
+                .with_readable(true)
+                .with_present(true)
+                .with_long(true)
+                .with_iopl(MachMode::User)
+        }
+        pub fn udata64() -> Descr {
+            Self::empty()
+                .with_system(true)
+                .with_code(false)
+                .with_readable(true)
+                .with_present(true)
+                .with_iopl(MachMode::User)
+        }
+    }
+
+    bitstruct! {
+        /// Interrupt Gate Descriptors are entries in the IDT.
+        #[derive(Clone, Copy, Default, FromZeros)]
+        #[repr(transparent)]
+        pub struct IntrGateDescr(u128) {
+            pub offset0: u16 = 0..16;
+            pub segment_selector: u16 = 16..32;
+            pub stack_table_index: u8 = 32..35;
+            mbz0: bool = 35;
+            mbz1: bool = 36;
+            mbz2: u8 = 37..40;
+            fixed_type: u8 = 40..44;
+            mbz3: bool = 44;
+            cpl: MachMode = 45..47;
+            pub present: bool = 47;
+            pub offset16: u16 = 48..64;
+            pub offset32: u32 = 64..96;
+            pub reserved0: u32 = 96..128;
+        }
+    }
+
+    impl IntrGateDescr {
+        pub const fn empty() -> IntrGateDescr {
+            const TYPE_INTERRUPT_GATE: u128 = 0b1110 << (32 + 8);
+            IntrGateDescr(TYPE_INTERRUPT_GATE)
+        }
+
+        pub fn new(thunk: &trap::Stub, stack_index: IstIndex) -> IntrGateDescr {
+            let ptr: *const trap::Stub = thunk;
+            let va = ptr.addr();
+            IntrGateDescr::empty()
+                .with_offset0(va.get_bits(0..16) as u16)
+                .with_offset16(va.get_bits(16..32) as u16)
+                .with_offset32(va.get_bits(32..64) as u32)
+                .with_stack_table_index(stack_index as u8)
+                .with_segment_selector(Gdt::ktextsel())
+                .with_present(true)
+                .with_cpl(MachMode::Kernel)
+        }
+    }
+
+    bitstruct! {
+        /// The Task State Descriptor provides the hardware with sufficient
+        /// information to locate the TSS in memory.  The TSS, in turn,
+        /// mostly holds stack pointers.
+        #[derive(Clone, Copy, Debug, FromZeros)]
+        #[repr(transparent)]
+        pub struct TaskStateDescr(u128) {
+            pub limit0: u16 = 0..16;
+            pub base0: u16 = 16..32;
+            pub base16: u8 = 32..40;
+            mbo0: bool = 40;
+            pub busy: bool = 41;
+            mbz0: bool = 42;
+            mbo1: bool = 43;
+            mbz1: bool = 44;
+            cpl: MachMode = 45..47;
+            pub present: bool = 47;
+            pub limit16: u8 = 48..52;
+            pub avl: bool = 52;
+            mbz2: bool = 53;
+            mbz3: bool = 54;
+            pub granularity: bool = 55;
+            pub base24: u8 = 56..64;
+            pub base32: u32 = 64..96;
+            reserved0: u8 = 96..104;
+            mbz4: u8 = 104..108;
+            reserved1: u32 = 108..128;
+        }
+    }
+
+    impl TaskStateDescr {
+        pub fn empty() -> Self {
+            const TYPE_TASK_AVAILABLE: u128 = 0b1001 << (8 + 32);
+            Self(TYPE_TASK_AVAILABLE)
+        }
+
+        pub(super) fn new(tss: &Tss) -> Self {
+            let ptr: *const Tss = tss;
+            let va = ptr.addr() as u64;
+            Self::empty()
+                .with_limit0(core::mem::size_of::<Tss>() as u16 - 1)
+                .with_base0(va.get_bits(0..16) as u16)
+                .with_base16(va.get_bits(16..24) as u8)
+                .with_cpl(MachMode::Kernel)
+                .with_present(true)
+                .with_avl(true)
+                .with_granularity(true)
+                .with_base24(va.get_bits(24..32) as u8)
+                .with_base32(va.get_bits(32..64) as u32)
+        }
+    }
+}
+
+#[derive(FromZeros)]
+#[repr(C, align(65536))]
+pub struct Gdt {
+    null: seg::Descr,
+    ktext: seg::Descr,
+    kdata: seg::Descr,
+    udata: seg::Descr,
+    utext: seg::Descr,
+    unused: seg::Descr,
+    task: seg::TaskStateDescr,
+}
+
+impl Gdt {
+    pub const fn ktextsel() -> u16 {
+        core::mem::offset_of!(Gdt, ktext) as u16
+    }
+    pub const fn utextsel() -> u16 {
+        core::mem::offset_of!(Gdt, utext) as u16
+    }
+    pub const fn tasksel() -> u16 {
+        core::mem::offset_of!(Gdt, task) as u16
+    }
+
+    pub fn init(&mut self, tss: &Tss) {
+        self.null = seg::Descr::empty();
+        self.ktext = seg::Descr::ktext64();
+        self.kdata = seg::Descr::kdata64();
+        self.udata = seg::Descr::udata64();
+        self.utext = seg::Descr::utext64();
+        self.unused = seg::Descr::empty();
+        self.task = seg::TaskStateDescr::new(tss);
+    }
+
+    /// # Safety
+    /// It is up to the caller to ensure that `self` has
+    /// been properly initialized.
+    pub unsafe fn load(&mut self) {
+        unsafe { cpu::lgdt(self) }
+    }
+
+    // On 64-bit return, SYSRETQ loads the CS with
+    // the value of star[48..64] + 16.  Why +16?
+    // For compatibility with legacy 32-bit
+    // systems: presumably the GDT would have 32-bit
+    // entries first, then 64-bit entries, and SYSRET
+    // returns to a 64-bit segment.
+    //
+    // On a 64-bit only system, this isn't an issue,
+    // but we still need to ensure the value in IA32_STAR
+    // at this offset is properly loaded.
+    //
+    // Interestingly, SS is loaded with star[48..64] + 8.
+    // In R9, this is the user data selector, which is
+    // exactly what we want.
+    //
+    // Note that SYSRET on Intel forces RPL on the
+    // loaded selectors to 3, but AMD only does this
+    // for CS and not SS.  So for portability, we
+    // explicitly OR a user RPL into the STAR bits.
+    // This is idempotent for CS.
+    pub fn star() -> u64 {
+        const RPL_USER: u64 = dat::MachMode::User as u64;
+        const UTEXTSEL: u64 = Gdt::utextsel() as u64;
+        const KTEXTSEL: u64 = Gdt::ktextsel() as u64;
+        ((UTEXTSEL - 16) | RPL_USER) << 48 | KTEXTSEL << 32
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IstIndex {
+    Rsp0 = 0,
+    Ist1 = 1,
+    Ist2 = 2,
+    Ist3 = 3,
+    Ist4 = 4,
+    Ist5 = 5,
+    Ist6 = 6,
+    Ist7 = 7,
+}
+
+impl IstIndex {
+    fn from_trap(trapno: u8) -> Self {
+        match trapno {
+            NMI_TRAPNO => IstIndex::Ist1,
+            DEBUG_TRAPNO => IstIndex::Ist2,
+            DOUBLE_FAULT_TRAPNO => IstIndex::Ist3,
+            _ => IstIndex::Rsp0,
+        }
+    }
+}
+
+#[derive(FromZeros)]
+#[repr(C)]
+pub struct Tss {
+    _res0: u32,
+    rsp0: [u32; 2],
+    _rsp1: [u32; 2],
+    _rsp2: [u32; 2],
+    _res1: u32,
+    ist1: [u32; 2],
+    ist2: [u32; 2],
+    ist3: [u32; 2],
+    ist4: [u32; 2],
+    ist5: [u32; 2],
+    ist6: [u32; 2],
+    ist7: [u32; 2],
+    _res3: u32,
+    _res4: u32,
+    _res5: u16,
+    iomb: u16,
+}
+
+impl Tss {
+    pub fn init(&mut self, stacks: &mut [(u8, &mut dyn dat::Stack)]) {
+        stacks.iter_mut().for_each(|(trapno, stack)| self.set_stack(*trapno, *stack));
+        self.iomb = core::mem::size_of::<Tss>() as u16;
+    }
+
+    pub fn set_rsp0(&mut self, stack: &mut dyn dat::Stack) {
+        self.set_stack(0, stack);
+    }
+
+    fn set_stack(&mut self, trapno: u8, stack: &mut dyn dat::Stack) {
+        let index = IstIndex::from_trap(trapno);
+        let va = stack.top_mut().addr();
+        let lower = va.get_bits(0..32) as u32;
+        let upper = va.get_bits(32..64) as u32;
+        match index {
+            IstIndex::Rsp0 => self.rsp0 = [lower, upper],
+            IstIndex::Ist1 => self.ist1 = [lower, upper],
+            IstIndex::Ist2 => self.ist2 = [lower, upper],
+            IstIndex::Ist3 => self.ist3 = [lower, upper],
+            IstIndex::Ist4 => self.ist4 = [lower, upper],
+            IstIndex::Ist5 => self.ist5 = [lower, upper],
+            IstIndex::Ist6 => self.ist6 = [lower, upper],
+            IstIndex::Ist7 => self.ist7 = [lower, upper],
+        }
+    }
+
+    /// # Safety
+    /// It is up to the caller to ensure that an appropriate GDT
+    /// is initialized and loaded, and that this TSS has been
+    /// initialized.
+    pub unsafe fn load(&mut self) {
+        unsafe {
+            cpu::ltr(Gdt::tasksel());
+        }
+    }
+}
+
+#[derive(FromZeros)]
+#[repr(C, align(4096))]
+pub struct Idt([seg::IntrGateDescr; 256]);
+
+impl Idt {
+    pub fn init(&mut self, stubs: &[trap::Stub; 256]) {
+        for (k, thunk) in stubs.iter().enumerate() {
+            let trapno = k as u8;
+            let index = IstIndex::from_trap(trapno);
+            self.0[k] = seg::IntrGateDescr::new(thunk, index);
+        }
+    }
+
+    /// # Safety
+    /// It is up to the caller to ensure that this IDT has been
+    /// properly initialized.
+    pub unsafe fn load(&mut self) {
+        unsafe {
+            cpu::lidt(self);
+        }
+    }
+}
+
+pub unsafe fn init(mach: &mut dat::Mach) {
+    const MSR_KERNEL_GS_BASE: u32 = 0xc0000102;
+    unsafe {
+        mach.init();
+        cpu::wrgsbase(mach as *mut dat::Mach as usize as u64);
+        cpu::wrmsr(MSR_KERNEL_GS_BASE, 0);
+    }
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2024"
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 target-lexicon = { version = "0.13.2" }
-toml = "0.8"
+toml = "0.9"


### PR DESCRIPTION
Add exception handling for x86_64, which also involves setting up a proper `Mach` structure, as well as doing all of the bits of required architectural goo.