### PR TITLE
Fix warnings, fix vm test

### DIFF
--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -10,6 +10,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests
+      run: |
+        cargo xtask check --verbose
+        cargo xtask clippy --verbose
+
   tests:
     runs-on: ubuntu-latest
 

--- a/port/src/mem.rs
+++ b/port/src/mem.rs
@@ -14,6 +14,10 @@ pub const PAGE_SIZE_1G: usize = 1 << 30;
 pub struct VirtRange(pub Range<usize>);
 
 impl VirtRange {
+    pub fn with_end(start: usize, end: usize) -> Self {
+        Self(start..end)
+    }
+
     pub fn with_len(start: usize, len: usize) -> Self {
         Self(start..start + len)
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-15"
+channel = "nightly-2026-01-30"
 components = ["rustfmt", "rust-src", "clippy", "llvm-tools"]
 targets = [
     "aarch64-unknown-none",

--- a/x86_64/src/main.rs
+++ b/x86_64/src/main.rs
@@ -51,7 +51,7 @@ pub extern "C" fn main(mach: &mut dat::Mach, _mbdata: u64) {
     println!("looping now");
     let mut ctx = Label::new();
     let mut thr = Label::new();
-    thr.pc = jumpback as usize as u64;
+    thr.pc = jumpback as *const () as usize as u64;
     unsafe {
         thr.sp = &mut THRSTACK[1023] as *mut _ as u64;
         CTX = &mut ctx as *mut _ as u64;

--- a/x86_64/src/syscall.rs
+++ b/x86_64/src/syscall.rs
@@ -11,7 +11,7 @@ pub(crate) fn init() {
     const MSR_LSTAR: u32 = 0xc000_0082;
     const MSR_FMASK: u32 = 0xc000_0084;
     unsafe {
-        cpu::wrmsr(MSR_LSTAR, entry as usize as u64);
+        cpu::wrmsr(MSR_LSTAR, entry as *const () as usize as u64);
         cpu::wrmsr(MSR_STAR, vsvm::Gdt::star());
         cpu::wrmsr(MSR_FMASK, cpu::fmask());
     }

--- a/x86_64/src/trap.rs
+++ b/x86_64/src/trap.rs
@@ -81,7 +81,7 @@ macro_rules! gen_trap_stub {
 }
 
 pub fn stubs() -> &'static [Stub; 256] {
-    unsafe { &*(intr_stubs as usize as *const [Stub; 256]) }
+    unsafe { &*(intr_stubs as *const () as usize as *const [Stub; 256]) }
 }
 
 /// intr_stubs is just a container for interrupt stubs.  It is


### PR DESCRIPTION
- Bump rust
- Clean all the clippy and check warnings and add github action to run them
-  Implement simple aarch64 vm test.  This involves some code rearrangement, but not much substantial change.