### PR TITLE
Change VirtRange to be a plain data structure, not based on Range.

### DIFF
--- a/aarch64/src/deviceutil.rs
+++ b/aarch64/src/deviceutil.rs
@@ -26,7 +26,7 @@ pub fn map_device_register(
         page_size,
         vm::RootPageTableType::Kernel,
     ) {
-        let offset = vr.start() - page_physrange.start().addr() as usize;
+        let offset = vr.start - page_physrange.start().addr() as usize;
         Ok(VirtRange::from_physrange(&physrange, offset))
     } else {
         Err("failed to map device register")

--- a/aarch64/src/mailbox.rs
+++ b/aarch64/src/mailbox.rs
@@ -146,7 +146,7 @@ where
         .as_mut()
         .map(|mb| {
             let msg = unsafe {
-                let page_va_ptr = mb.req_buffer_va.start() as u64 as *mut MessageWithTags<T, U>;
+                let page_va_ptr = mb.req_buffer_va.start as u64 as *mut MessageWithTags<T, U>;
                 core::intrinsics::volatile_set_memory(page_va_ptr, 0, 1);
                 let msg = NonNull::new_unchecked(page_va_ptr).as_mut();
                 msg.request.size = size;

--- a/aarch64/src/main.rs
+++ b/aarch64/src/main.rs
@@ -101,7 +101,7 @@ fn print_stacks() {
 
     let interrupt_stack_base = unsafe { interruptstackbase.as_ptr().addr() };
     let interrupt_stack_max = interrupt_stack_base + unsafe { interruptstacksz.as_ptr().addr() };
-    let range = VirtRange(interrupt_stack_base..interrupt_stack_max);
+    let range = VirtRange::new(interrupt_stack_base, interrupt_stack_max);
     let range_size = range.size();
     println!("Interrupt stack:\t {range} ({range_size:#x})");
 }

--- a/aarch64/src/pagealloc.rs
+++ b/aarch64/src/pagealloc.rs
@@ -102,7 +102,7 @@ pub fn allocate_virtpage(
         pgtype,
     ) {
         // println!("pagealloc:allocate_virtpage:va:{:#x} -> physpage:{:?}", page_va.start(), page_pa);
-        let virtpage = page_va.start() as *mut VirtPage4K;
+        let virtpage = page_va.start as *mut VirtPage4K;
         Ok(unsafe { &mut *virtpage })
     } else {
         println!("error:pagealloc:allocate_virtpage:unable to map");

--- a/aarch64/src/pre_mmu/vminit.rs
+++ b/aarch64/src/pre_mmu/vminit.rs
@@ -169,9 +169,9 @@ pub extern "C" fn init_vm(dtb_pa: u64) {
             panic!();
         };
 
-        putu64h(mapped_virtrange.start() as u64);
+        putu64h(mapped_virtrange.start as u64);
         putstr("..");
-        putu64h(mapped_virtrange.end() as u64);
+        putu64h(mapped_virtrange.end as u64);
         putstr("\n");
     }
     // puttable(&root_page_table);
@@ -365,7 +365,7 @@ fn map_phys_range<A: PageAllocator>(
             putstr("\n");
         }
     }
-    startva.map(|startva| VirtRange(startva..endva)).ok_or(PageTableError::PhysRangeIsZero)
+    startva.map(|startva| VirtRange::new(startva, endva)).ok_or(PageTableError::PhysRangeIsZero)
 }
 
 /// Ensure there's a mapping from va to entry, creating any intermediate

--- a/aarch64/src/vm.rs
+++ b/aarch64/src/vm.rs
@@ -507,7 +507,7 @@ impl RootPageTable {
                 pgtype,
             )?;
         }
-        let mapped_virtrange = startva.map(|startva| VirtRange(startva..endva));
+        let mapped_virtrange = startva.map(|startva| VirtRange::new(startva, endva));
         mapped_virtrange.ok_or(PageTableError::PhysRangeIsZero)
     }
 }
@@ -858,6 +858,6 @@ mod tests {
             )
             .expect("error:init:mapping failed");
 
-        assert_eq!(mapped_virtrange, VirtRange::with_end(KZERO + 4096, KZERO + 8 * 4096));
+        assert_eq!(mapped_virtrange, VirtRange::new(KZERO + 4096, KZERO + 8 * 4096));
     }
 }

--- a/port/src/mem.rs
+++ b/port/src/mem.rs
@@ -10,37 +10,36 @@ pub const PAGE_SIZE_4K: usize = 4 << 10;
 pub const PAGE_SIZE_2M: usize = 2 << 20;
 pub const PAGE_SIZE_1G: usize = 1 << 30;
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct VirtRange(pub Range<usize>);
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct VirtRange {
+    pub start: usize,
+    pub end: usize,
+}
 
 impl VirtRange {
-    pub fn with_end(start: usize, end: usize) -> Self {
-        Self(start..end)
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
     }
 
     pub fn with_len(start: usize, len: usize) -> Self {
-        Self(start..start + len)
+        Self { start, end: start + len }
     }
 
     pub fn from_physrange(pr: &PhysRange, offset: usize) -> Self {
-        Self((pr.0.start.0 as usize + offset)..(pr.0.end.0 as usize + offset))
+        Self { start: pr.0.start.0 as usize + offset, end: pr.0.end.0 as usize + offset }
     }
 
     pub fn offset_addr(&self, offset: usize) -> Option<usize> {
-        let addr = self.0.start + offset;
-        if self.0.contains(&addr) { Some(addr) } else { None }
-    }
-
-    pub fn start(&self) -> usize {
-        self.0.start
-    }
-
-    pub fn end(&self) -> usize {
-        self.0.end
+        let addr = self.start + offset;
+        if self.contains(addr) { Some(addr) } else { None }
     }
 
     pub fn size(&self) -> usize {
-        self.0.end - self.0.start
+        self.end - self.start
+    }
+
+    pub fn contains(&self, addr: usize) -> bool {
+        addr >= self.start && addr < self.end
     }
 }
 
@@ -48,13 +47,13 @@ impl From<&RegBlock> for VirtRange {
     fn from(r: &RegBlock) -> Self {
         let start = r.addr as usize;
         let end = start + r.len.unwrap_or(0) as usize;
-        VirtRange(start..end)
+        VirtRange { start, end }
     }
 }
 
 impl fmt::Display for VirtRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:#018x}..{:#018x}", self.0.start, self.0.end)
+        write!(f, "{:#018x}..{:#018x}", self.start, self.end)
     }
 }
 


### PR DESCRIPTION
Range isn't copyable for various Rusty reasons and we can't just derive Copy.
Simplifies other code as we don't need to borrow the reference.

Tried and abandoned a similar change a few months ago (#68), but feels like the right choice now.