### PR TITLE
port: add IRQ masking primitives and interrupt-context tracking

### DIFF
--- a/aarch64/src/irq.rs
+++ b/aarch64/src/irq.rs
@@ -1,0 +1,36 @@
+//! DAIF-based implementation of the portable interrupt masking hooks.
+
+use port::irq::IrqOps;
+
+static IRQ_OPS: IrqOps = IrqOps { mask: mask_irqs, restore: restore_irqs };
+
+/// Register DAIF masking with `port::irq`.  Must be called before
+/// interrupts are enabled.
+pub fn init() {
+    port::irq::set_ops(&IRQ_OPS);
+}
+
+/// Mask IRQs on this core, returning the previous DAIF state.
+fn mask_irqs() -> u64 {
+    let daif: u64;
+    unsafe {
+        core::arch::asm!(
+            "mrs {daif}, daif",
+            "msr daifset, #2",
+            daif = out(reg) daif,
+            options(nostack, preserves_flags)
+        );
+    }
+    daif
+}
+
+/// Restore a DAIF state previously returned by `mask_irqs`.
+fn restore_irqs(daif: u64) {
+    unsafe {
+        core::arch::asm!(
+            "msr daif, {daif}",
+            daif = in(reg) daif,
+            options(nostack, preserves_flags)
+        );
+    }
+}

--- a/aarch64/src/main.rs
+++ b/aarch64/src/main.rs
@@ -12,6 +12,7 @@ mod allocator;
 mod devcons;
 mod deviceutil;
 mod io;
+mod irq;
 mod kmem;
 mod mailbox;
 mod pagealloc;
@@ -112,6 +113,7 @@ fn print_stacks() {
 /// assumed to be dtb_va-KZERO.
 #[unsafe(no_mangle)]
 pub extern "C" fn main9(dtb_va: usize) {
+    irq::init();
     trap::init();
 
     // Parse the DTB before we set up memory so we can correctly map it

--- a/aarch64/src/trap.rs
+++ b/aarch64/src/trap.rs
@@ -103,7 +103,9 @@ impl fmt::Debug for TrapFrame {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn trap_unsafe(frame: *mut TrapFrame) {
+    port::irq::enter_interrupt();
     unsafe { trap(frame.as_mut().unwrap()) }
+    port::irq::exit_interrupt();
 }
 
 fn trap(frame: &mut TrapFrame) {

--- a/port/src/irq.rs
+++ b/port/src/irq.rs
@@ -1,0 +1,93 @@
+//! Core-local interrupt masking and interrupt-context tracking.
+//!
+//! Any lock that is also taken in interrupt context (e.g. the console
+//! lock) must be held with interrupts masked; otherwise an interrupt
+//! arriving while the lock is held leaves the handler spinning on a
+//! lock its own core can never release.  `IrqGuard` provides that
+//! masking as an RAII guard.
+//!
+//! `in_interrupt` supports the complementary approach for subsystems
+//! that interrupt context is simply forbidden to use (e.g. the
+//! allocator): assert the invariant instead of masking around it.
+//!
+//! Masking is architecture-specific, so each arch registers its
+//! implementation at early boot via `set_ops`, before enabling
+//! interrupts (the pattern devcons uses for the Uart).  Until then, and
+//! in hosted test builds where the mask instructions would be
+//! privileged, `IrqGuard` is a no-op.
+
+use core::marker::PhantomData;
+use core::ptr;
+use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+
+// Depth rather than a flag so nested exceptions stay counted.
+// Core-local in spirit; needs to become per-core state under SMP.
+static INTERRUPT_DEPTH: AtomicUsize = AtomicUsize::new(0);
+
+/// Mark entry to interrupt context.  Called by the arch trap handler.
+pub fn enter_interrupt() {
+    INTERRUPT_DEPTH.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Mark exit from interrupt context.  Called by the arch trap handler.
+pub fn exit_interrupt() {
+    INTERRUPT_DEPTH.fetch_sub(1, Ordering::Relaxed);
+}
+
+/// True while the current core is handling an interrupt or exception.
+pub fn in_interrupt() -> bool {
+    INTERRUPT_DEPTH.load(Ordering::Relaxed) > 0
+}
+
+/// Architecture hooks for masking interrupts on the current core.
+/// `mask` masks interrupts and returns the previous interrupt state;
+/// `restore` reinstates a state previously returned by `mask`.
+pub struct IrqOps {
+    pub mask: fn() -> u64,
+    pub restore: fn(u64),
+}
+
+static IRQ_OPS: AtomicPtr<IrqOps> = AtomicPtr::new(ptr::null_mut());
+
+/// Register the architecture's mask/restore implementation.  Call once
+/// at early boot, before interrupts are first enabled.
+pub fn set_ops(ops: &'static IrqOps) {
+    IRQ_OPS.store(ops as *const IrqOps as *mut IrqOps, Ordering::Release);
+}
+
+fn ops() -> Option<&'static IrqOps> {
+    let ops = IRQ_OPS.load(Ordering::Acquire);
+    unsafe { ops.as_ref() }
+}
+
+/// Masks interrupts on the current core for its lifetime, restoring the
+/// previous mask state on drop.  Nestable: taking a guard with
+/// interrupts already masked (e.g. in interrupt context) is a no-op.
+/// Create the guard before acquiring any lock shared with interrupt
+/// context, and let it drop after the lock is released.
+pub struct IrqGuard {
+    saved: Option<u64>,
+    // The saved state is core-local, so the guard must not move to
+    // another core: !Send + !Sync.
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl IrqGuard {
+    pub fn new() -> Self {
+        Self { saved: ops().map(|ops| (ops.mask)()), _not_send: PhantomData }
+    }
+}
+
+impl Default for IrqGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for IrqGuard {
+    fn drop(&mut self) {
+        if let (Some(saved), Some(ops)) = (self.saved, ops()) {
+            (ops.restore)(saved);
+        }
+    }
+}

--- a/port/src/lib.rs
+++ b/port/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bitmapalloc;
 pub mod dat;
 pub mod devcons;
 pub mod fdt;
+pub mod irq;
 pub mod maths;
 pub mod mcslock;
 pub mod mem;


### PR DESCRIPTION
Add port::irq with an RAII IrqGuard (mask IRQs on new, restore the previous state on drop; nestable; no-op until an arch registers its mask/restore hooks) and an interrupt-depth counter (enter_interrupt/ exit_interrupt/in_interrupt) so subsystems can either mask around locks shared with interrupt context or assert they are never used from it.

aarch64 registers a DAIF-based implementation at early boot and brackets the trap handler with the depth counter.  Other arches are unaffected: the guard is a no-op and in_interrupt is always false until they opt in.